### PR TITLE
Plugin improvements

### DIFF
--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -70,7 +70,6 @@ export function search(...plugins: (Plugin | PluginVisitor)[]): LanguagePhase {
 export interface Plugin {
   name: string;
   visit: PluginVisitor;
-  visitRoot?: PluginVisitor;
 }
 
 type TokenTreeArray = Array<string | TokenTreeArray>;

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -69,6 +69,9 @@ export function search(...plugins: (Plugin | PluginVisitor)[]): LanguagePhase {
 
 export interface Plugin {
   name: string;
+  /** visit should return one or more viable replacement nodes, or undefined to represent
+   * no replacement. The replacement nodes should be different in value than
+   * the initial node if it compares different under reference equality */
   visit: PluginVisitor;
 }
 

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -39,33 +39,38 @@ export interface LanguagePhase {
   plugins: Plugin[];
 }
 
-export function required(...plugins: Plugin[]): LanguagePhase {
+function languagePhase(
+  mode: LanguagePhaseMode,
+  plugins: (Plugin | PluginVisitor)[],
+): LanguagePhase {
   return {
-    mode: "required",
-    plugins,
+    mode,
+    plugins: plugins.map((x) =>
+      typeof x === "function" ? { name: x.name, visit: x } : x,
+    ),
   };
 }
 
-export function simplegolf(...plugins: Plugin[]): LanguagePhase {
-  return {
-    mode: "simplegolf",
-    plugins,
-  };
+export function required(
+  ...plugins: (Plugin | PluginVisitor)[]
+): LanguagePhase {
+  return languagePhase("required", plugins);
 }
 
-export function search(...plugins: Plugin[]): LanguagePhase {
-  return {
-    mode: "search",
-    plugins,
-  };
+export function simplegolf(
+  ...plugins: (Plugin | PluginVisitor)[]
+): LanguagePhase {
+  return languagePhase("simplegolf", plugins);
+}
+
+export function search(...plugins: (Plugin | PluginVisitor)[]): LanguagePhase {
+  return languagePhase("search", plugins);
 }
 
 export interface Plugin {
   name: string;
-  /** visit should return one or more viable replacement nodes, or undefined to represent
-   * no replacement. The replacement nodes should be different in value than
-   * the initial node if it compares different under reference equality */
-  visit: PluginVisitor<IR.Node[] | IR.Node | undefined>;
+  visit: PluginVisitor;
+  visitRoot?: PluginVisitor;
 }
 
 type TokenTreeArray = Array<string | TokenTreeArray>;

--- a/src/common/Spine.ts
+++ b/src/common/Spine.ts
@@ -178,7 +178,9 @@ export class Spine<N extends IR.Node = IR.Node> {
   }
 }
 
-export type PluginVisitor<T> = <N extends IR.Node>(
+export type PluginVisitor<T = IR.Node[] | IR.Node | undefined> = <
+  N extends IR.Node,
+>(
   node: N,
   spine: Spine<N>,
   context: CompilationContext,

--- a/src/common/Spine.ts
+++ b/src/common/Spine.ts
@@ -105,7 +105,7 @@ export class Spine<N extends IR.Node = IR.Node> {
    * if the values are not used. Name inspired by Swift's `compactMap`. */
   *compactMap<T>(func: Visitor<T | undefined>): Generator<T, void, undefined> {
     let skipChildren = false;
-    function skip(kind: "replacement" | "children" | "replacementChildren") {
+    function skip(kind: "replacement" | "children") {
       skipChildren = kind === "children";
     }
     const ret = func(this.node, this, skip);
@@ -146,7 +146,7 @@ export class Spine<N extends IR.Node = IR.Node> {
   ): Spine {
     let skipReplacement = skipReplaced;
     let skipChildren = false;
-    function skip(kind: "replacement" | "children" | "replacementChildren") {
+    function skip(kind: "replacement" | "children") {
       skipReplacement ||= kind === "replacement";
       skipChildren ||= kind === "children";
     }

--- a/src/languages/javascript/plugins.ts
+++ b/src/languages/javascript/plugins.ts
@@ -1,72 +1,72 @@
-import { builtin, forEachKey, indexCall, isIntLiteral, text } from "../../IR";
-import type { Plugin } from "../../common/Language";
+import {
+  type Node,
+  builtin,
+  forEachKey,
+  indexCall,
+  isIntLiteral,
+  text,
+} from "../../IR";
 
-export const propertyCallToIndexCall: Plugin = {
-  name: "propertyCallToIndexCall",
-  visit(node) {
-    if (node.kind === "PropertyCall") {
-      return indexCall(node.object, text(node.ident.name));
-    }
-  },
-};
+export function propertyCallToIndexCall(node: Node) {
+  if (node.kind === "PropertyCall") {
+    return indexCall(node.object, text(node.ident.name));
+  }
+}
 
-export const forRangeToForEachKey: Plugin = {
-  name: "forRangeToForEachKey",
-  visit(node) {
-    if (
-      node.kind === "ForRange" &&
-      node.variable !== undefined &&
-      isIntLiteral(0n)(node.start) &&
-      isIntLiteral()(node.end) &&
-      2 <= node.end.value &&
-      node.end.value <= 37
-    ) {
-      const end = Number(node.end.value);
-      return forEachKey(
-        node.variable,
-        builtin(
-          [
-            "'??'",
-            "'???'",
-            "''+!0",
-            "''+!1",
-            "''+1e5",
-            "''+1e6",
-            "''+1e7",
-            "''+1e8",
-            "''+1e9",
-            "''+1e10",
-            "''+1e11",
-            "''+1e12",
-            "''+1e13",
-            "''+{}",
-            "{}+1",
-            "{}+11",
-            "{}+.1",
-            "{}+!0",
-            "{}+!1",
-            "{}+1e5",
-            "{}+1e6",
-            "{}+1e7",
-            "{}+1e8",
-            "{}+1e9",
-            "{}+1e10",
-            "{}+1e11",
-            "{}+1e12",
-            "{}+1e13",
-            "{}+{}",
-            "{}+1e15",
-            "''+Map",
-            " 1+Map",
-            "-1+Map",
-            ".1+Map",
-            "!0+Map",
-            "!1+Map",
-            "{}+Map",
-          ][end - 2],
-        ),
-        node.body,
-      );
-    }
-  },
-};
+export function forRangeToForEachKey(node: Node) {
+  if (
+    node.kind === "ForRange" &&
+    node.variable !== undefined &&
+    isIntLiteral(0n)(node.start) &&
+    isIntLiteral()(node.end) &&
+    2 <= node.end.value &&
+    node.end.value <= 37
+  ) {
+    const end = Number(node.end.value);
+    return forEachKey(
+      node.variable,
+      builtin(
+        [
+          "'??'",
+          "'???'",
+          "''+!0",
+          "''+!1",
+          "''+1e5",
+          "''+1e6",
+          "''+1e7",
+          "''+1e8",
+          "''+1e9",
+          "''+1e10",
+          "''+1e11",
+          "''+1e12",
+          "''+1e13",
+          "''+{}",
+          "{}+1",
+          "{}+11",
+          "{}+.1",
+          "{}+!0",
+          "{}+!1",
+          "{}+1e5",
+          "{}+1e6",
+          "{}+1e7",
+          "{}+1e8",
+          "{}+1e9",
+          "{}+1e10",
+          "{}+1e11",
+          "{}+1e12",
+          "{}+1e13",
+          "{}+{}",
+          "{}+1e15",
+          "''+Map",
+          " 1+Map",
+          "-1+Map",
+          ".1+Map",
+          "!0+Map",
+          "!1+Map",
+          "{}+Map",
+        ][end - 2],
+      ),
+      node.body,
+    );
+  }
+}

--- a/src/languages/lua/plugins.ts
+++ b/src/languages/lua/plugins.ts
@@ -6,26 +6,22 @@ import {
   isIntLiteral,
   isOp,
 } from "../../IR";
-import { type Plugin } from "../../common/Language";
 
-export const base10DecompositionToFloatLiteralAsBuiltin: Plugin = {
-  name: "base10DecompositionToFloatLiteralAsBuiltin",
-  visit(node) {
-    let k = 1n;
-    let pow: Node = node;
-    if (isOp("mul")(node) && isIntLiteral()(node.args[0])) {
-      k = node.args[0].value;
-      pow = node.args[1];
-    }
+export function base10DecompositionToFloatLiteralAsBuiltin(node: Node) {
+  let k = 1n;
+  let pow: Node = node;
+  if (isOp("mul")(node) && isIntLiteral()(node.args[0])) {
+    k = node.args[0].value;
+    pow = node.args[1];
+  }
 
-    if (
-      isOp("pow")(pow) &&
-      isIntLiteral(10n)(pow.args[0]) &&
-      isIntLiteral()(pow.args[1])
-    ) {
-      const e = pow.args[1].value;
-      const value = k * 10n ** e;
-      return annotate(builtin(`${k}e${e}`), integerType(value, value));
-    }
-  },
-};
+  if (
+    isOp("pow")(pow) &&
+    isIntLiteral(10n)(pow.args[0]) &&
+    isIntLiteral()(pow.args[1])
+  ) {
+    const e = pow.args[1].value;
+    const value = k * 10n ** e;
+    return annotate(builtin(`${k}e${e}`), integerType(value, value));
+  }
+}

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -1,4 +1,5 @@
 import {
+  type Node,
   importStatement,
   integerType,
   isIdent,
@@ -10,8 +11,9 @@ import {
   op,
 } from "../../IR";
 import { getType } from "../../common/getType";
-import { type Plugin } from "../../common/Language";
+import type { Plugin } from "../../common/Language";
 import { addImports } from "../../plugins/imports";
+import type { Spine } from "../../common/Spine";
 
 const includes: [string, string[]][] = [
   ["re", ["strutils"]],
@@ -60,29 +62,23 @@ export const addNimImports: Plugin = addImports(
   },
 );
 
-export const useUnsignedDivision: Plugin = {
-  name: "useUnsignedDivision",
-  visit(node, spine) {
-    if (isOp("trunc_div", "rem")(node)) {
-      return isSubtype(getType(node.args[0], spine), integerType(0)) &&
-        isSubtype(getType(node.args[0], spine), integerType(0))
-        ? op(`unsigned_${node.op}`, ...node.args)
-        : undefined;
-    }
-  },
-};
+export function useUnsignedDivision(node: Node, spine: Spine) {
+  if (isOp("trunc_div", "rem")(node)) {
+    return isSubtype(getType(node.args[0], spine), integerType(0)) &&
+      isSubtype(getType(node.args[0], spine), integerType(0))
+      ? op(`unsigned_${node.op}`, ...node.args)
+      : undefined;
+  }
+}
 
-export const useUFCS: Plugin = {
-  name: "useUFCS",
-  visit(node) {
-    if (node.kind === "FunctionCall" && node.args.length > 0) {
-      if (node.args.length === 1 && isText()(node.args[0])) {
-        return;
-      }
-      const [obj, ...args] = node.args;
-      if (!isOfKind("Infix", "Prefix")(obj) && isIdent()(node.func)) {
-        return methodCall(obj, node.func, ...args);
-      }
+export function useUFCS(node: Node) {
+  if (node.kind === "FunctionCall" && node.args.length > 0) {
+    if (node.args.length === 1 && isText()(node.args[0])) {
+      return;
     }
-  },
-};
+    const [obj, ...args] = node.args;
+    if (!isOfKind("Infix", "Prefix")(obj) && isIdent()(node.func)) {
+      return methodCall(obj, node.func, ...args);
+    }
+  }
+}

--- a/src/markdown-tests/index.ts
+++ b/src/markdown-tests/index.ts
@@ -8,6 +8,7 @@ import compile, {
 import { findLang } from "../languages/languages";
 import { type Plugin } from "../common/Language";
 import { getOnlyVariant } from "../common/expandVariants";
+import type { PluginVisitor } from "../common/Spine";
 
 export const keywords = [
   "nogolf",
@@ -62,7 +63,7 @@ export function testLang(
 
 export function testPlugin(
   name: string,
-  plugins: Plugin[],
+  plugins: (Plugin | PluginVisitor)[],
   args: string[],
   input: string,
   output: string,
@@ -76,7 +77,7 @@ export function testPlugin(
             addWarning: () => {},
             options: compilationOptionsFromKeywords(args),
           },
-          ...plugins.map((x) => x.visit),
+          ...plugins.map((x) => (typeof x === "function" ? x : x.visit)),
         )[0],
       ),
     ).toEqual(normalize(output));

--- a/src/markdown-tests/index.ts
+++ b/src/markdown-tests/index.ts
@@ -73,10 +73,8 @@ export function testPlugin(
       debugEmit(
         applyAllToAllAndGetCounts(
           getOnlyVariant(parse(input, false)),
-          {
-            addWarning: () => {},
-            options: compilationOptionsFromKeywords(args),
-          },
+          compilationOptionsFromKeywords(args),
+          () => {},
           ...plugins.map((x) => (typeof x === "function" ? x : x.visit)),
         )[0],
       ),

--- a/src/plugins/arithmetic.ts
+++ b/src/plugins/arithmetic.ts
@@ -20,142 +20,124 @@ import { mapOps } from "./ops";
 import { type Spine } from "@/common/Spine";
 import { filterInplace } from "../common/arrays";
 
-export const modToRem: Plugin = {
-  name: "modToRem",
-  visit(node, spine) {
-    if (isOp("mod")(node)) {
-      return isSubtype(getType(node.args[1], spine), integerType(0))
-        ? op("rem", ...node.args)
-        : op(
-            "rem",
-            op("add", op("rem", ...node.args), node.args[1]),
-            node.args[1],
-          );
-    }
-  },
-};
+export function modToRem(node: Node, spine: Spine) {
+  if (isOp("mod")(node)) {
+    return isSubtype(getType(node.args[1], spine), integerType(0))
+      ? op("rem", ...node.args)
+      : op(
+          "rem",
+          op("add", op("rem", ...node.args), node.args[1]),
+          node.args[1],
+        );
+  }
+}
 
-export const divToTruncdiv: Plugin = {
-  name: "divToTruncdiv",
-  visit(node, spine) {
-    if (isOp("div")(node)) {
-      return isSubtype(getType(node.args[1], spine), integerType(0))
-        ? op("trunc_div", ...node.args)
-        : undefined; // TODO
-    }
-  },
-};
+export function divToTruncdiv(node: Node, spine: Spine) {
+  if (isOp("div")(node)) {
+    return isSubtype(getType(node.args[1], spine), integerType(0))
+      ? op("trunc_div", ...node.args)
+      : undefined; // TODO
+  }
+}
 
 export const truncatingOpsPlugins = [modToRem, divToTruncdiv];
 
-export const equalityToInequality: Plugin = {
-  name: "equalityToInequality",
-  visit(node, spine) {
-    if (isOp("eq", "neq")(node)) {
-      const eq = node.op === "eq";
-      const [a, b] = [node.args[0], node.args[1]];
-      const [t1, t2] = [a, b].map((x) => getType(x, spine)) as [
-        IntegerType,
-        IntegerType,
-      ];
-      if (isConstantType(t1)) {
-        if (t1.low === t2.low) {
-          // (0 == $x:0..9) -> (1 > $x:0..9)
-          // (0 != $x:0..9) -> (0 < $x:0..9)
-          return eq ? op("gt", int(t1.low + 1n), b) : op("lt", int(t1.low), b);
-        }
-        if (t1.low === t2.high) {
-          // (9 == $x:0..9) -> (8 < $x:0..9)
-          // (9 != $x:0..9) -> (9 > $x:0..9)
-          return eq ? op("lt", int(t1.low - 1n), b) : op("gt", int(t1.low), b);
-        }
+export function equalityToInequality(node: Node, spine: Spine) {
+  if (isOp("eq", "neq")(node)) {
+    const eq = node.op === "eq";
+    const [a, b] = [node.args[0], node.args[1]];
+    const [t1, t2] = [a, b].map((x) => getType(x, spine)) as [
+      IntegerType,
+      IntegerType,
+    ];
+    if (isConstantType(t1)) {
+      if (t1.low === t2.low) {
+        // (0 == $x:0..9) -> (1 > $x:0..9)
+        // (0 != $x:0..9) -> (0 < $x:0..9)
+        return eq ? op("gt", int(t1.low + 1n), b) : op("lt", int(t1.low), b);
       }
-
-      if (isConstantType(t2)) {
-        if (t1.low === t2.low) {
-          // ($x:0..9 == 0) -> ($x:0..9 < 1)
-          // ($x:0..9 != 0) -> ($x:0..9 > 0)
-          return eq ? op("lt", a, int(t2.low + 1n)) : op("gt", a, int(t2.low));
-        }
-        if (t1.high === t2.low) {
-          // ($x:0..9 == 9) -> ($x:0..9 > 8)
-          // ($x:0..9 != 9) -> ($x:0..9 < 9)
-          return eq ? op("gt", a, int(t2.low - 1n)) : op("lt", a, int(t2.low));
-        }
+      if (t1.low === t2.high) {
+        // (9 == $x:0..9) -> (8 < $x:0..9)
+        // (9 != $x:0..9) -> (9 > $x:0..9)
+        return eq ? op("lt", int(t1.low - 1n), b) : op("gt", int(t1.low), b);
       }
     }
-  },
-};
+
+    if (isConstantType(t2)) {
+      if (t1.low === t2.low) {
+        // ($x:0..9 == 0) -> ($x:0..9 < 1)
+        // ($x:0..9 != 0) -> ($x:0..9 > 0)
+        return eq ? op("lt", a, int(t2.low + 1n)) : op("gt", a, int(t2.low));
+      }
+      if (t1.high === t2.low) {
+        // ($x:0..9 == 9) -> ($x:0..9 > 8)
+        // ($x:0..9 != 9) -> ($x:0..9 < 9)
+        return eq ? op("gt", a, int(t2.low - 1n)) : op("lt", a, int(t2.low));
+      }
+    }
+  }
+}
 
 export const removeBitnot: Plugin = mapOps(
   { bit_not: (x) => op("sub", int(-1), x[0]) },
   "removeBitnot",
 );
 
-export const addBitnot: Plugin = {
-  name: "addBitnot",
-  visit(node) {
-    if (
-      isOp("add")(node) &&
-      node.args.length === 2 &&
-      isIntLiteral()(node.args[0])
-    ) {
-      if (node.args[0].value === 1n)
-        return op("neg", op("bit_not", node.args[1]));
-      if (node.args[0].value === -1n)
-        return op("bit_not", op("neg", node.args[1]));
-    }
-  },
-};
+export function addBitnot(node: Node) {
+  if (
+    isOp("add")(node) &&
+    node.args.length === 2 &&
+    isIntLiteral()(node.args[0])
+  ) {
+    if (node.args[0].value === 1n)
+      return op("neg", op("bit_not", node.args[1]));
+    if (node.args[0].value === -1n)
+      return op("bit_not", op("neg", node.args[1]));
+  }
+}
 
 export const bitnotPlugins = [removeBitnot, addBitnot];
 
-export const applyDeMorgans: Plugin = {
-  name: "applyDeMorgans",
-  visit(node, spine) {
-    if (isOp("and", "or", "unsafe_and", "unsafe_or")(node)) {
-      const negation = op(
-        node.op === "and"
-          ? "or"
-          : node.op === "or"
-          ? "and"
-          : node.op === "unsafe_and"
-          ? "unsafe_or"
-          : "unsafe_and",
-        ...node.args.map((x) => op("not", x)),
-      );
-      if (getType(node, spine).kind === "void") return negation; // If we are promised we won't read the result, we don't need to negate.
-      return op("not", negation);
-    }
-    if (isOp("bit_and", "bit_or")(node)) {
-      return op(
-        "bit_not",
-        op(
-          node.op === "bit_and" ? "bit_or" : "bit_and",
-          ...node.args.map((x) => op("bit_not", x)),
-        ),
-      );
-    }
-  },
-};
+export function applyDeMorgans(node: Node, spine: Spine) {
+  if (isOp("and", "or", "unsafe_and", "unsafe_or")(node)) {
+    const negation = op(
+      node.op === "and"
+        ? "or"
+        : node.op === "or"
+        ? "and"
+        : node.op === "unsafe_and"
+        ? "unsafe_or"
+        : "unsafe_and",
+      ...node.args.map((x) => op("not", x)),
+    );
+    if (getType(node, spine).kind === "void") return negation; // If we are promised we won't read the result, we don't need to negate.
+    return op("not", negation);
+  }
+  if (isOp("bit_and", "bit_or")(node)) {
+    return op(
+      "bit_not",
+      op(
+        node.op === "bit_and" ? "bit_or" : "bit_and",
+        ...node.args.map((x) => op("bit_not", x)),
+      ),
+    );
+  }
+}
 
-export const useIntegerTruthiness: Plugin = {
-  name: "useIntegerTruthiness",
-  visit(node, spine) {
-    if (
-      isOp("eq", "neq")(node) &&
-      spine.parent!.node.kind === "If" &&
-      spine.pathFragment === "condition"
-    ) {
-      const res = isIntLiteral(0n)(node.args[1])
-        ? implicitConversion("int_to_bool", node.args[0])
-        : isIntLiteral(0n)(node.args[0])
-        ? implicitConversion("int_to_bool", node.args[1])
-        : undefined;
-      return res !== undefined && node.op === "eq" ? op("not", res) : res;
-    }
-  },
-};
+export function useIntegerTruthiness(node: Node, spine: Spine) {
+  if (
+    isOp("eq", "neq")(node) &&
+    spine.parent!.node.kind === "If" &&
+    spine.pathFragment === "condition"
+  ) {
+    const res = isIntLiteral(0n)(node.args[1])
+      ? implicitConversion("int_to_bool", node.args[0])
+      : isIntLiteral(0n)(node.args[0])
+      ? implicitConversion("int_to_bool", node.args[1])
+      : undefined;
+    return res !== undefined && node.op === "eq" ? op("not", res) : res;
+  }
+}
 
 function isConstantTypePowerOfTwo(n: Node, s: Spine) {
   const type = getType(n, s);
@@ -173,31 +155,25 @@ function isPowerOfTwo(n: Node, s: Spine): boolean {
   );
 }
 
-export const modToBitand: Plugin = {
-  name: "modToBitand",
-  visit(node, spine) {
-    if (isOp("mod")(node)) {
-      const n = node.args[1];
-      if (isPowerOfTwo(n, spine)) {
-        return op("bit_and", node.args[0], sub1(n));
-      }
+export function modToBitand(node: Node, spine: Spine) {
+  if (isOp("mod")(node)) {
+    const n = node.args[1];
+    if (isPowerOfTwo(n, spine)) {
+      return op("bit_and", node.args[0], sub1(n));
     }
-  },
-};
+  }
+}
 
-export const bitandToMod: Plugin = {
-  name: "bitandToMod",
-  visit(node, spine) {
-    if (isOp("bit_and")(node)) {
-      for (const i of [0, 1]) {
-        const n = add1(node.args[i]);
-        if (isPowerOfTwo(n, spine)) {
-          return op("mod", node.args[1 - i], n);
-        }
+export function bitandToMod(node: Node, spine: Spine) {
+  if (isOp("bit_and")(node)) {
+    for (const i of [0, 1]) {
+      const n = add1(node.args[i]);
+      if (isPowerOfTwo(n, spine)) {
+        return op("mod", node.args[1 - i], n);
       }
     }
-  },
-};
+  }
+}
 
 export const lowBitsPlugins = [modToBitand, bitandToMod];
 
@@ -215,30 +191,27 @@ export function powToMul(limit: number = 2): Plugin {
   };
 }
 
-export const mulToPow: Plugin = {
-  name: "mulToPow",
-  visit(node) {
-    if (isOp("mul")(node)) {
-      const factors = new Map<string, [Node, number]>();
-      for (const e of node.args) {
-        const stringified = stringify(e);
-        factors.set(stringified, [
-          e,
-          1 + ((factors.get(stringified)?.at(1) as number) ?? 0),
-        ]);
-      }
-      const pairs = [...factors.values()];
-      if (pairs.some((pair) => pair[1] > 1)) {
-        return op(
-          "mul",
-          ...pairs.map(([expr, exp]) =>
-            exp > 1 ? op("pow", expr, int(exp)) : expr,
-          ),
-        );
-      }
+export function mulToPow(node: Node, spine: Spine) {
+  if (isOp("mul")(node)) {
+    const factors = new Map<string, [Node, number]>();
+    for (const e of node.args) {
+      const stringified = stringify(e);
+      factors.set(stringified, [
+        e,
+        1 + ((factors.get(stringified)?.at(1) as number) ?? 0),
+      ]);
     }
-  },
-};
+    const pairs = [...factors.values()];
+    if (pairs.some((pair) => pair[1] > 1)) {
+      return op(
+        "mul",
+        ...pairs.map(([expr, exp]) =>
+          exp > 1 ? op("pow", expr, int(exp)) : expr,
+        ),
+      );
+    }
+  }
+}
 
 export const powPlugins = [powToMul(), mulToPow];
 
@@ -473,13 +446,10 @@ export function decomposeIntLiteral(
   };
 }
 
-export const pickAnyInt: Plugin = {
-  name: "pickAnyInt",
-  visit(node) {
-    if (node.kind === "AnyInteger") {
-      return node.low.toString().length < node.high.toString().length
-        ? int(node.low)
-        : int(node.high);
-    }
-  },
-};
+export function pickAnyInt(node: Node) {
+  if (node.kind === "AnyInteger") {
+    return node.low.toString().length < node.high.toString().length
+      ? int(node.low)
+      : int(node.high);
+  }
+}

--- a/src/plugins/block.ts
+++ b/src/plugins/block.ts
@@ -258,7 +258,7 @@ export function inlineVariables(
   spine: Spine,
   context: CompilationContext,
 ) {
-  context.skip("children");
+  context.skipChildren();
   const writes = groupby(getWrites(spine), (x) => x.node.name);
   const suggestions = [];
   for (const a of writes.values()) {

--- a/src/plugins/block.ts
+++ b/src/plugins/block.ts
@@ -82,18 +82,15 @@ export function blockChildrenCollectAndReplace<T extends Node = Node>(
 }
 
 const declared: Set<string> = new Set<string>();
-export const addVarDeclarations: Plugin = {
-  name: "addVarDeclarations",
-  visit(node, spine) {
-    if (spine.isRoot) declared.clear();
-    if (node.kind === "Assignment") {
-      if (isIdent()(node.variable) && !declared.has(node.variable.name)) {
-        declared.add(node.variable.name);
-        return varDeclarationWithAssignment(node);
-      }
+export function addVarDeclarations(node: Node, spine: Spine) {
+  if (spine.isRoot) declared.clear();
+  if (node.kind === "Assignment") {
+    if (isIdent()(node.variable) && !declared.has(node.variable.name)) {
+      declared.add(node.variable.name);
+      return varDeclarationWithAssignment(node);
     }
-  },
-};
+  }
+}
 
 /**
  * Replaces `v1 = c; v2 = c; ... ; vn = c` with `v1,v2,...vn=c`
@@ -213,96 +210,87 @@ export function groupVarDeclarations(
   );
 }
 
-export const noStandaloneVarDeclarations: Plugin = {
-  name: "noStandaloneVarDeclarations",
-  visit(node, spine) {
-    if (
-      (node.kind === "VarDeclaration" ||
-        node.kind === "VarDeclarationWithAssignment") &&
-      spine.parent?.node.kind !== "VarDeclarationBlock"
-    ) {
-      return varDeclarationBlock([node]);
-    }
-  },
-};
+export function noStandaloneVarDeclarations(node: Node, spine: Spine) {
+  if (
+    (node.kind === "VarDeclaration" ||
+      node.kind === "VarDeclarationWithAssignment") &&
+    spine.parent?.node.kind !== "VarDeclarationBlock"
+  ) {
+    return varDeclarationBlock([node]);
+  }
+}
 
-export const tempVarToMultipleAssignment: Plugin = {
-  name: "tempVarToMultipleAssignment",
-  visit(node) {
-    if (node.kind === "Block") {
-      const newNodes: Node[] = [];
-      let changed = false;
-      for (let i = 0; i < node.children.length; i++) {
-        const a = node.children[i];
-        if (i >= node.children.length - 2) {
-          newNodes.push(a);
-          continue;
-        }
-        const b = node.children[i + 1];
-        const c = node.children[i + 2];
+export function tempVarToMultipleAssignment(node: Node) {
+  if (node.kind === "Block") {
+    const newNodes: Node[] = [];
+    let changed = false;
+    for (let i = 0; i < node.children.length; i++) {
+      const a = node.children[i];
+      if (i >= node.children.length - 2) {
+        newNodes.push(a);
+        continue;
+      }
+      const b = node.children[i + 1];
+      const c = node.children[i + 2];
+      if (
+        isAssignmentToIdentifier(a) &&
+        isAssignment(b) &&
+        isAssignmentToIdentifier(c) &&
+        isIdent(c.variable)(b.expr) &&
+        isIdent(a.variable)(c.expr)
+      ) {
+        newNodes.push(
+          manyToManyAssignment([b.variable, c.variable], [b.expr, a.expr]),
+        );
+        changed = true;
+        i += 2;
+      } else {
+        newNodes.push(a);
+      }
+    }
+    if (changed) return block(newNodes);
+  }
+}
+
+export function inlineVariables(node: Node, spine: Spine) {
+  if (spine.isRoot) {
+    const writes = groupby(getWrites(spine), (x) => x.node.name);
+    const suggestions = [];
+    for (const a of writes.values()) {
+      if (a.length === 1) {
+        const variable = a[0].node;
+        const write = a[0].parent!;
         if (
-          isAssignmentToIdentifier(a) &&
-          isAssignment(b) &&
-          isAssignmentToIdentifier(c) &&
-          isIdent(c.variable)(b.expr) &&
-          isIdent(a.variable)(c.expr)
+          write.node.kind === "Assignment" &&
+          write.parent?.node.kind === "Block" &&
+          spine.someNode(
+            (n) => n !== variable && isUserIdent(variable)(n), // in tests variables are often never read from and we don't want to make those disappear
+          ) &&
+          !write.getChild("expr").someNode(isUserIdent(variable)) &&
+          !hasSideEffect(write.getChild("expr"))
         ) {
-          newNodes.push(
-            manyToManyAssignment([b.variable, c.variable], [b.expr, a.expr]),
+          const assignmentToInlineSpine = write as Spine<
+            Assignment<Identifier>
+          >;
+          const assignment = assignmentToInlineSpine.node;
+          const assignmentParent = assignmentToInlineSpine.parent?.node;
+          suggestions.push(
+            spine.withReplacer((x) =>
+              x === assignmentParent && x.kind === "Block"
+                ? blockOrSingle(x.children.filter((y) => y !== assignment))
+                : x.kind === "Identifier" &&
+                  !x.builtin &&
+                  x.name === assignment.variable.name
+                ? {
+                    ...assignment.expr,
+                    type: assignment.expr.type ?? assignment.variable.type,
+                  }
+                : undefined,
+            ).node,
           );
-          changed = true;
-          i += 2;
-        } else {
-          newNodes.push(a);
         }
       }
-      if (changed) return block(newNodes);
     }
-  },
-};
-
-export const inlineVariables: Plugin = {
-  name: "inlineVariables",
-  visit(node, spine) {
-    if (spine.isRoot) {
-      const writes = groupby(getWrites(spine), (x) => x.node.name);
-      const suggestions = [];
-      for (const a of writes.values()) {
-        if (a.length === 1) {
-          const variable = a[0].node;
-          const write = a[0].parent!;
-          if (
-            write.node.kind === "Assignment" &&
-            write.parent?.node.kind === "Block" &&
-            spine.someNode(
-              (n) => n !== variable && isUserIdent(variable)(n), // in tests variables are often never read from and we don't want to make those disappear
-            ) &&
-            !write.getChild("expr").someNode(isUserIdent(variable)) &&
-            !hasSideEffect(write.getChild("expr"))
-          ) {
-            const assignmentToInlineSpine = write as Spine<
-              Assignment<Identifier>
-            >;
-            const assignment = assignmentToInlineSpine.node;
-            const assignmentParent = assignmentToInlineSpine.parent?.node;
-            suggestions.push(
-              spine.withReplacer((x) =>
-                x === assignmentParent && x.kind === "Block"
-                  ? blockOrSingle(x.children.filter((y) => y !== assignment))
-                  : x.kind === "Identifier" &&
-                    !x.builtin &&
-                    x.name === assignment.variable.name
-                  ? {
-                      ...assignment.expr,
-                      type: assignment.expr.type ?? assignment.variable.type,
-                    }
-                  : undefined,
-              ).node,
-            );
-          }
-        }
-      }
-      return suggestions;
-    }
-  },
-};
+    return suggestions;
+  }
+}

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -64,8 +64,8 @@ export function renameIdents(
 ): Plugin {
   return {
     name: "renameIdents(...)",
-    visit(program, spine) {
-      if (!spine.isRoot) return;
+    visit(program, spine, context) {
+      context.skip("children");
       const identMap = getIdentMap(spine.root, identGen);
       return spine.withReplacer((node) => {
         if (isUserIdent()(node)) {
@@ -113,8 +113,8 @@ export function alias(
           (key.length - save[0]) * (freq - 1) - save[0] - save[1];
   return {
     name: "alias(...)",
-    visit(prog, spine) {
-      if (!spine.isRoot) return;
+    visit(prog, spine, context) {
+      context.skip("children");
       // get frequency of expr
       const timesUsed = new Map<string, number>();
       for (const key of spine.compactMap(getKey)) {

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -65,7 +65,7 @@ export function renameIdents(
   return {
     name: "renameIdents(...)",
     visit(program, spine, context) {
-      context.skip("children");
+      context.skipChildren();
       const identMap = getIdentMap(spine.root, identGen);
       return spine.withReplacer((node) => {
         if (isUserIdent()(node)) {
@@ -114,7 +114,7 @@ export function alias(
   return {
     name: "alias(...)",
     visit(prog, spine, context) {
-      context.skip("children");
+      context.skipChildren();
       // get frequency of expr
       const timesUsed = new Map<string, number>();
       for (const key of spine.compactMap(getKey)) {

--- a/src/plugins/imports.ts
+++ b/src/plugins/imports.ts
@@ -25,7 +25,7 @@ export function addImports( // TODO caching
   return {
     name: "addImports(...)",
     visit(node, spine, context) {
-      context.skip("children");
+      context.skipChildren();
       const modules = spine.compactMap(rulesFunc);
       const outputNode = outputFunc([...new Set(modules)]);
       if (outputNode !== undefined) {

--- a/src/plugins/imports.ts
+++ b/src/plugins/imports.ts
@@ -24,8 +24,8 @@ export function addImports( // TODO caching
 
   return {
     name: "addImports(...)",
-    visit(node, spine) {
-      if (!spine.isRoot) return;
+    visit(node, spine, context) {
+      context.skip("children");
       const modules = spine.compactMap(rulesFunc);
       const outputNode = outputFunc([...new Set(modules)]);
       if (outputNode !== undefined) {

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -54,48 +54,42 @@ export function forRangeToForRangeInclusive(skip1Step = false): Plugin {
   };
 }
 
-export const forRangeToWhile: Plugin = {
-  name: "forRangeToWhile",
-  visit(node, spine) {
-    if (node.kind === "ForRange" && node.variable !== undefined) {
-      const low = getType(node.start, spine);
-      const high = getType(node.end, spine);
-      if (low.kind !== "integer" || high.kind !== "integer") {
-        throw new Error(`Unexpected type (${low.kind},${high.kind})`);
-      }
-      const increment = assignment(
-        node.variable,
-        op("add", node.variable, node.increment),
-      );
-      return block([
-        assignment(node.variable, node.start),
-        whileLoop(
-          op(node.inclusive ? "leq" : "lt", node.variable, node.end),
-          block([node.body, increment]),
-        ),
-      ]);
+export function forRangeToWhile(node: Node, spine: Spine) {
+  if (node.kind === "ForRange" && node.variable !== undefined) {
+    const low = getType(node.start, spine);
+    const high = getType(node.end, spine);
+    if (low.kind !== "integer" || high.kind !== "integer") {
+      throw new Error(`Unexpected type (${low.kind},${high.kind})`);
     }
-  },
-};
-
-export const forRangeToForCLike: Plugin = {
-  name: "forRangeToForCLike",
-  visit(node, spine) {
-    if (node.kind === "ForRange" && node.variable !== undefined) {
-      const low = getType(node.start, spine);
-      const high = getType(node.end, spine);
-      if (low.kind !== "integer" || high.kind !== "integer") {
-        throw new Error(`Unexpected type (${low.kind},${high.kind})`);
-      }
-      return forCLike(
-        assignment(node.variable, node.start),
+    const increment = assignment(
+      node.variable,
+      op("add", node.variable, node.increment),
+    );
+    return block([
+      assignment(node.variable, node.start),
+      whileLoop(
         op(node.inclusive ? "leq" : "lt", node.variable, node.end),
-        assignment(node.variable, op("add", node.variable, node.increment)),
-        node.body,
-      );
+        block([node.body, increment]),
+      ),
+    ]);
+  }
+}
+
+export function forRangeToForCLike(node: Node, spine: Spine) {
+  if (node.kind === "ForRange" && node.variable !== undefined) {
+    const low = getType(node.start, spine);
+    const high = getType(node.end, spine);
+    if (low.kind !== "integer" || high.kind !== "integer") {
+      throw new Error(`Unexpected type (${low.kind},${high.kind})`);
     }
-  },
-};
+    return forCLike(
+      assignment(node.variable, node.start),
+      op(node.inclusive ? "leq" : "lt", node.variable, node.end),
+      assignment(node.variable, op("add", node.variable, node.increment)),
+      node.body,
+    );
+  }
+}
 
 /**
  * Python:
@@ -107,28 +101,25 @@ export const forRangeToForCLike: Plugin = {
  *     commands(i, x)
  */
 // TODO: Handle inclusive like Lua's `for i=1,#L do commands(i, L[i]) end
-export const forRangeToForEachPair: Plugin = {
-  name: "forRangeToForEachPair",
-  visit(node, spine) {
-    if (
-      node.kind === "ForRange" &&
-      node.variable !== undefined &&
-      !node.inclusive &&
-      isIntLiteral(0n)(node.start) &&
-      isOp("list_length")(node.end) &&
-      isIdent()(node.end.args[0])
-    ) {
-      const variable = node.variable;
-      const collection = node.end.args[0];
-      const elementIdentifier = id(variable.name + "+each");
-      const newBody = spine.getChild("body").withReplacer((innerNode) => {
-        if (isListGet(innerNode, collection.name, variable.name))
-          return elementIdentifier;
-      }).node;
-      return forEachPair(variable, elementIdentifier, collection, newBody);
-    }
-  },
-};
+export function forRangeToForEachPair(node: Node, spine: Spine) {
+  if (
+    node.kind === "ForRange" &&
+    node.variable !== undefined &&
+    !node.inclusive &&
+    isIntLiteral(0n)(node.start) &&
+    isOp("list_length")(node.end) &&
+    isIdent()(node.end.args[0])
+  ) {
+    const variable = node.variable;
+    const collection = node.end.args[0];
+    const elementIdentifier = id(variable.name + "+each");
+    const newBody = spine.getChild("body").withReplacer((innerNode) => {
+      if (isListGet(innerNode, collection.name, variable.name))
+        return elementIdentifier;
+    }).node;
+    return forEachPair(variable, elementIdentifier, collection, newBody);
+  }
+}
 
 function isListGet(node: IR.Node, collection: string, index: string) {
   return (
@@ -259,14 +250,11 @@ function literalLength(expr: Text | List, countTextBytes: boolean): number {
   return (countTextBytes ? byteLength : charLength)(expr.value);
 }
 
-export const forArgvToForEach: Plugin = {
-  name: "forArgvToForEach",
-  visit(node) {
-    if (node.kind === "ForArgv") {
-      return forEach(node.variable, op("argv"), node.body);
-    }
-  },
-};
+export function forArgvToForEach(node: Node) {
+  if (node.kind === "ForArgv") {
+    return forEach(node.variable, op("argv"), node.body);
+  }
+}
 
 export function forArgvToForRange(overshoot = true, inclusive = false): Plugin {
   return {
@@ -295,71 +283,65 @@ export function forArgvToForRange(overshoot = true, inclusive = false): Plugin {
   };
 }
 
-export const assertForArgvTopLevel: Plugin = {
-  name: "assertForArgvTopLevel",
-  visit(node, spine) {
-    if (spine.isRoot) {
-      let forArgvSeen = false;
-      for (const kind of spine.compactMap((x) => x.kind)) {
-        if (kind === "ForArgv") {
-          if (forArgvSeen)
-            throw new PolygolfError(
-              "Only a single for_argv node allowed.",
-              node.source,
-            );
-          forArgvSeen = true;
-        }
+export function assertForArgvTopLevel(node: Node, spine: Spine) {
+  if (spine.isRoot) {
+    let forArgvSeen = false;
+    for (const kind of spine.compactMap((x) => x.kind)) {
+      if (kind === "ForArgv") {
+        if (forArgvSeen)
+          throw new PolygolfError(
+            "Only a single for_argv node allowed.",
+            node.source,
+          );
+        forArgvSeen = true;
       }
     }
-    if (node.kind === "ForArgv") {
-      if (
-        !(
-          spine.isRoot ||
-          (spine.parent?.node.kind === "Block" && spine.parent.isRoot)
-        )
-      ) {
-        throw new PolygolfError(
-          "Node for_argv only allowed at the top level.",
-          node.source,
-        );
-      }
-    }
-    return undefined;
-  },
-};
-
-export const shiftRangeOneUp: Plugin = {
-  name: "shiftRangeOneUp",
-  visit(node, spine) {
+  }
+  if (node.kind === "ForArgv") {
     if (
-      node.kind === "ForRange" &&
-      node.variable !== undefined &&
-      isIntLiteral(1n)(node.increment) &&
-      spine.someNode(
-        (x) =>
-          isOp("add")(x) &&
-          isIntLiteral(1n)(x.args[0]) &&
-          isIdent(node.variable!)(x.args[1]),
+      !(
+        spine.isRoot ||
+        (spine.parent?.node.kind === "Block" && spine.parent.isRoot)
       )
     ) {
-      const bodySpine = spine.getChild("body");
-      const newVar = id(node.variable.name + "+shift");
-      const newBodySpine = bodySpine.withReplacer((x) =>
-        newVar !== undefined && isIdent(node.variable!)(x)
-          ? sub1(newVar)
-          : undefined,
-      );
-      return forRange(
-        newVar,
-        add1(node.start),
-        add1(node.end),
-        int(1n),
-        newBodySpine.node,
-        node.inclusive,
+      throw new PolygolfError(
+        "Node for_argv only allowed at the top level.",
+        node.source,
       );
     }
-  },
-};
+  }
+  return undefined;
+}
+
+export function shiftRangeOneUp(node: Node, spine: Spine) {
+  if (
+    node.kind === "ForRange" &&
+    node.variable !== undefined &&
+    isIntLiteral(1n)(node.increment) &&
+    spine.someNode(
+      (x) =>
+        isOp("add")(x) &&
+        isIntLiteral(1n)(x.args[0]) &&
+        isIdent(node.variable!)(x.args[1]),
+    )
+  ) {
+    const bodySpine = spine.getChild("body");
+    const newVar = id(node.variable.name + "+shift");
+    const newBodySpine = bodySpine.withReplacer((x) =>
+      newVar !== undefined && isIdent(node.variable!)(x)
+        ? sub1(newVar)
+        : undefined,
+    );
+    return forRange(
+      newVar,
+      add1(node.start),
+      add1(node.end),
+      int(1n),
+      newBodySpine.node,
+      node.inclusive,
+    );
+  }
+}
 
 export function forRangeToForDifferenceRange(
   transformPredicate: (
@@ -388,52 +370,46 @@ export function forRangeToForDifferenceRange(
   };
 }
 
-export const forRangeToForRangeOneStep: Plugin = {
-  name: "forRangeToForRangeOneStep",
-  visit(node, spine) {
-    if (
-      node.kind === "ForRange" &&
-      node.variable !== undefined &&
-      isSubtype(getType(node.increment, spine.root.node), integerType(2n))
-    ) {
-      const newVar = id(node.variable.name + "+1step");
-      return forRange(
-        newVar,
-        int(0n),
-        node.inclusive
-          ? op("div", op("sub", node.end, node.start), node.increment)
-          : add1(
-              op("div", op("sub", sub1(node.end), node.start), node.increment),
-            ),
-        int(1n),
-        block([
-          assignment(
-            node.variable,
-            op("add", op("mul", newVar, node.increment), node.start),
+export function forRangeToForRangeOneStep(node: Node, spine: Spine) {
+  if (
+    node.kind === "ForRange" &&
+    node.variable !== undefined &&
+    isSubtype(getType(node.increment, spine.root.node), integerType(2n))
+  ) {
+    const newVar = id(node.variable.name + "+1step");
+    return forRange(
+      newVar,
+      int(0n),
+      node.inclusive
+        ? op("div", op("sub", node.end, node.start), node.increment)
+        : add1(
+            op("div", op("sub", sub1(node.end), node.start), node.increment),
           ),
-          node.body,
-        ]),
+      int(1n),
+      block([
+        assignment(
+          node.variable,
+          op("add", op("mul", newVar, node.increment), node.start),
+        ),
+        node.body,
+      ]),
+      node.inclusive,
+    );
+  }
+}
+
+export function removeUnusedForVar(node: Node, spine: Spine) {
+  if (node.kind === "ForRange" && node.variable !== undefined) {
+    const variable = node.variable;
+    if (!spine.getChild("body").someNode(isUserIdent(variable))) {
+      return forRange(
+        undefined,
+        node.start,
+        node.end,
+        node.increment,
+        node.body,
         node.inclusive,
       );
     }
-  },
-};
-
-export const removeUnusedForVar: Plugin = {
-  name: "removeUnusedForVar",
-  visit(node, spine) {
-    if (node.kind === "ForRange" && node.variable !== undefined) {
-      const variable = node.variable;
-      if (!spine.getChild("body").someNode(isUserIdent(variable))) {
-        return forRange(
-          undefined,
-          node.start,
-          node.end,
-          node.increment,
-          node.body,
-          node.inclusive,
-        );
-      }
-    }
-  },
-};
+  }
+}

--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -243,49 +243,37 @@ export function addMutatingInfix(
   };
 }
 
-export const addPostfixIncAndDec: Plugin = {
-  name: "addPostfixIncAndDec",
-  visit(node) {
-    if (
-      node.kind === "MutatingInfix" &&
-      ["+", "-"].includes(node.name) &&
-      isIntLiteral(1n)(node.right)
-    ) {
-      return postfix(node.name.repeat(2), node.variable);
-    }
-  },
-};
+export function addPostfixIncAndDec(node: Node) {
+  if (
+    node.kind === "MutatingInfix" &&
+    ["+", "-"].includes(node.name) &&
+    isIntLiteral(1n)(node.right)
+  ) {
+    return postfix(node.name.repeat(2), node.variable);
+  }
+}
 
 // (a > b) --> (b < a)
-export const flipBinaryOps: Plugin = {
-  name: "flipBinaryOps",
-  visit(node) {
-    if (isOp(...BinaryOpCodes)(node)) {
-      const flippedOpCode = flipOpCode(node.op);
-      if (flippedOpCode !== null) {
-        return op(flippedOpCode, node.args[1], node.args[0]);
-      }
+export function flipBinaryOps(node: Node) {
+  if (isOp(...BinaryOpCodes)(node)) {
+    const flippedOpCode = flipOpCode(node.op);
+    if (flippedOpCode !== null) {
+      return op(flippedOpCode, node.args[1], node.args[0]);
     }
-  },
-};
+  }
+}
 
-export const removeImplicitConversions: Plugin = {
-  name: "removeImplicitConversions",
-  visit(node) {
-    if (node.kind === "ImplicitConversion") {
-      return node.expr;
-    }
-  },
-};
+export function removeImplicitConversions(node: Node) {
+  if (node.kind === "ImplicitConversion") {
+    return node.expr;
+  }
+}
 
-export const methodsAsFunctions: Plugin = {
-  name: "methodsAsFunctions",
-  visit(node) {
-    if (node.kind === "MethodCall") {
-      return functionCall(propertyCall(node.object, node.ident), node.args);
-    }
-  },
-};
+export function methodsAsFunctions(node: Node) {
+  if (node.kind === "MethodCall") {
+    return functionCall(propertyCall(node.object, node.ident), node.args);
+  }
+}
 
 export const printIntToPrint: Plugin = mapOps(
   {

--- a/src/plugins/packing.ts
+++ b/src/plugins/packing.ts
@@ -1,5 +1,5 @@
-import { type Plugin } from "../common/Language";
 import {
+  type Node,
   assignment,
   block,
   forRangeCommon,
@@ -12,50 +12,48 @@ import {
   text,
 } from "../IR";
 import { byteLength } from "../common/objective";
+import type { Spine } from "../common/Spine";
 
-export const useDecimalConstantPackedPrinter: Plugin = {
-  name: "useDecimalConstantPackedPrinter",
-  visit(node) {
-    if (
-      isOp("print", "println")(node) &&
-      isText()(node.args[0]) &&
-      isLargeDecimalConstant(node.args[0].value)
-    ) {
-      const [prefix, main] = node.args[0].value.replace(".", ".,").split(",");
-      const packed = packDecimal(main);
-      return block([
-        assignment("result", text(prefix)),
-        forRangeCommon(
-          ["packindex", 0, packed.length],
-          assignment(
-            "result",
+export function useDecimalConstantPackedPrinter(node: Node, spine: Spine) {
+  if (
+    isOp("print", "println")(node) &&
+    isText()(node.args[0]) &&
+    isLargeDecimalConstant(node.args[0].value)
+  ) {
+    const [prefix, main] = node.args[0].value.replace(".", ".,").split(",");
+    const packed = packDecimal(main);
+    return block([
+      assignment("result", text(prefix)),
+      forRangeCommon(
+        ["packindex", 0, packed.length],
+        assignment(
+          "result",
+          op(
+            "concat",
+            id("result"),
             op(
-              "concat",
-              id("result"),
+              "text_get_byte_slice",
               op(
-                "text_get_byte_slice",
+                "int_to_text",
                 op(
-                  "int_to_text",
+                  "add",
+                  int(72n),
                   op(
-                    "add",
-                    int(72n),
-                    op(
-                      "text_byte_to_int",
-                      op("text_get_byte", text(packed), id("packindex")),
-                    ),
+                    "text_byte_to_int",
+                    op("text_get_byte", text(packed), id("packindex")),
                   ),
                 ),
-                int(1n),
-                int(2n),
               ),
+              int(1n),
+              int(2n),
             ),
           ),
         ),
-        print(id("result")),
-      ]);
-    }
-  },
-};
+      ),
+      print(id("result")),
+    ]);
+  }
+}
 
 function isLargeDecimalConstant(output: string): boolean {
   return /^\d\.\d*$/.test(output) && output.length > 200;
@@ -68,19 +66,16 @@ function packDecimal(decimal: string): string {
   return result;
 }
 
-export const useLowDecimalListPackedPrinter: Plugin = {
-  name: "useLowDecimalListPackedPrinter",
-  visit(node) {
-    if (isOp("print", "println")(node) && isText()(node.args[0])) {
-      const packed = packLowDecimalList(node.args[0].value);
-      if (packed === null) return;
-      return forRangeCommon(
-        ["packindex", 0, packed.length],
-        print(op("text_get_byte_to_int", text(packed), id("packindex"))),
-      );
-    }
-  },
-};
+export function useLowDecimalListPackedPrinter(node: Node) {
+  if (isOp("print", "println")(node) && isText()(node.args[0])) {
+    const packed = packLowDecimalList(node.args[0].value);
+    if (packed === null) return;
+    return forRangeCommon(
+      ["packindex", 0, packed.length],
+      print(op("text_get_byte_to_int", text(packed), id("packindex"))),
+    );
+  }
+}
 
 function packLowDecimalList(value: string): string | null {
   if (/^[\d+\n]+[\d+]$/.test(value)) {

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -19,7 +19,7 @@ export function golfLastPrint(toPrintln = true): Plugin {
   return {
     name: "golfLastPrint",
     visit(program, spine, context) {
-      context.skip("children");
+      context.skipChildren();
       const newOp = toPrintln ? ("println" as const) : ("print" as const);
       const oldOp = toPrintln ? "print" : "println";
       if (isOp(oldOp)(program)) {

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -1,6 +1,7 @@
+import type { Spine } from "../common/Spine";
 import { replaceAtIndex } from "../common/arrays";
 import { type Plugin } from "../common/Language";
-import { block, implicitConversion, isOp, op, text } from "../IR";
+import { block, implicitConversion, isOp, type Node, op, text } from "../IR";
 import { mapOps } from "./ops";
 
 export const printLnToPrint = mapOps(
@@ -40,14 +41,11 @@ export function golfLastPrint(toPrintln = true): Plugin {
   };
 }
 
-export const implicitlyConvertPrintArg: Plugin = {
-  name: "implicitlyConvertPrintArg",
-  visit(node, spine) {
-    if (
-      isOp("int_to_text")(node) &&
-      isOp("print", "println")(spine.parent!.node)
-    ) {
-      return implicitConversion(node.op, node.args[0]);
-    }
-  },
-};
+export function implicitlyConvertPrintArg(node: Node, spine: Spine) {
+  if (
+    isOp("int_to_text")(node) &&
+    isOp("print", "println")(spine.parent!.node)
+  ) {
+    return implicitConversion(node.op, node.args[0]);
+  }
+}

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -18,8 +18,8 @@ export const printLnToPrint = mapOps(
 export function golfLastPrint(toPrintln = true): Plugin {
   return {
     name: "golfLastPrint",
-    visit(program, spine) {
-      if (!spine.isRoot) return;
+    visit(program, spine, context) {
+      context.skip("children");
       const newOp = toPrintln ? ("println" as const) : ("print" as const);
       const oldOp = toPrintln ? "print" : "println";
       if (isOp(oldOp)(program)) {

--- a/src/plugins/tables.ts
+++ b/src/plugins/tables.ts
@@ -127,19 +127,16 @@ export function testTableHashing(maxMod: number): Plugin {
   };
 }
 
-export const tableToListLookup: Plugin = {
-  name: "tableToListLookup",
-  visit(node) {
-    if (isOp("table_get")(node) && node.args[0].kind === "Table") {
-      const keys = node.args[0].kvPairs.map((x) => x.key);
-      if (
-        keys.every(isOfKind("Integer", "Text")) &&
-        new Set(keys.map((x) => x.value)).size === keys.length
-      ) {
-        const values = node.args[0].kvPairs.map((x) => x.value);
-        const at = node.args[1];
-        return op("list_get", list(values), op("list_find", list(keys), at));
-      }
+export function tableToListLookup(node: Node) {
+  if (isOp("table_get")(node) && node.args[0].kind === "Table") {
+    const keys = node.args[0].kvPairs.map((x) => x.key);
+    if (
+      keys.every(isOfKind("Integer", "Text")) &&
+      new Set(keys.map((x) => x.value)).size === keys.length
+    ) {
+      const values = node.args[0].kvPairs.map((x) => x.value);
+      const at = node.args[1];
+      return op("list_get", list(values), op("list_find", list(keys), at));
     }
-  },
-};
+  }
+}

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,3 +1,4 @@
+import type { Spine } from "../common/Spine";
 import { PolygolfError } from "../common/errors";
 import { getType } from "../common/getType";
 import { type Plugin } from "../common/Language";
@@ -18,25 +19,22 @@ import {
   annotate,
 } from "../IR";
 
-export const assertInt64: Plugin = {
-  name: "assertInt64",
-  visit(node, spine) {
-    if (spine.isRoot) return;
-    let type: Type;
-    try {
-      type = getType(node, spine);
-    } catch {
-      return; // stuff like builtin identifiers etc. throw
-    }
-    if (isSubtype(type, integerType()) && !isSubtype(type, int64Type)) {
-      throw new PolygolfError(
-        `Integer value that doesn't provably fit into a int64 type encountered.`,
-        node.source,
-      );
-    }
-    return undefined;
-  },
-};
+export function assertInt64(node: Node, spine: Spine) {
+  if (spine.isRoot) return;
+  let type: Type;
+  try {
+    type = getType(node, spine);
+  } catch {
+    return; // stuff like builtin identifiers etc. throw
+  }
+  if (isSubtype(type, integerType()) && !isSubtype(type, int64Type)) {
+    throw new PolygolfError(
+      `Integer value that doesn't provably fit into a int64 type encountered.`,
+      node.source,
+    );
+  }
+  return undefined;
+}
 
 export function floodBigints(
   primitiveIntType0: "int64" | "int53" | IntegerType,


### PR DESCRIPTION
- Allows one to use `PluginVisitor` directly instead of `Plugin` since it's just a simple wrapper.
- Adds access to a `skip` function to plugins. Once called, traversing to the replacement / to any children is skipped.
- Uses previous point to replace `if (spine.isRoot){logic}` with `context.skip("children"); logic` in several plugins.