### PR TITLE
Add noEmit flag for testing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import yargs from "yargs";
 import fs from "fs";
 import path from "path";
-import compile, { debugEmit, compilationOptions } from "./common/compile";
+import compile, { debugEmit } from "./common/compile";
 import { PolygolfError } from "./common/errors";
 import languages, { findLang } from "./languages/languages";
 import { EmitError } from "./common/emit";
@@ -62,10 +62,10 @@ const code = fs.readFileSync(input, { encoding: "utf-8" });
 const printingMultipleLangs = langs.length > 1 && options.output === undefined;
 for (const result of compile(
   code,
-  compilationOptions({
+  {
     objective: options.chars === true ? "chars" : "bytes",
     getAllVariants: options.all === true,
-  }),
+  },
   ...langs,
 )) {
   if (printingMultipleLangs) console.log(result.language);

--- a/src/common/Language.ts
+++ b/src/common/Language.ts
@@ -27,6 +27,7 @@ export interface Language {
   extension: string;
   phases: LanguagePhase[];
   emitter: Emitter;
+  noEmitter?: Emitter; // emitter used with the `noEmit` flag
   packers?: Packer[];
   detokenizer?: Detokenizer;
   readsFromStdinOnCodeDotGolf?: boolean;

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -8,7 +8,7 @@ import {
 } from "../IR";
 import { readsFromInput } from "../common/symbols";
 import { PolygolfError } from "../common/errors";
-import { compilationOptions, compileVariant } from "../common/compile";
+import { compileVariant } from "../common/compile";
 import javascriptLanguage from "../languages/javascript";
 import { required } from "../common/Language";
 import { addVarDeclarations } from "../plugins/block";
@@ -57,7 +57,7 @@ function _getOutput(program: Node): string {
     throw new PolygolfError("Program reads from input.");
   const jsCode = compileVariant(
     program,
-    compilationOptions({ level: "nogolf" }),
+    { level: "nogolf" },
     javascriptForInterpreting,
   );
   if (typeof jsCode.result !== "string") {

--- a/src/markdown-tests/index.ts
+++ b/src/markdown-tests/index.ts
@@ -23,6 +23,7 @@ export const keywords = [
   "1..127",
   "32..127",
   "no:hardcode",
+  "noEmit",
 ] as const;
 
 export function compilationOptionsFromKeywords(
@@ -42,6 +43,7 @@ export function compilationOptionsFromKeywords(
     restrictFrontend: is("restrictFrontend"),
     skipTypecheck: isLangTest ? is("skipTypecheck") : !is("typecheck"),
     skipPlugins: is("no:hardcode") ? ["hardcode"] : [],
+    noEmit: is("noEmit"),
   };
 }
 


### PR DESCRIPTION
- adds noEmit flag - With this flag, polygolf emit or custom noe emit emitter are used instead of the normal emitter. Useful for languages with complex emitters.
- make `compile` function only expect `Partial<CompilationOptions>` instead of `CompilationOptions` so that we no longer break the playground whenever we add an option.