### PR TITLE
fix gs print

### DIFF
--- a/src/languages/golfscript/golfscript.test.md
+++ b/src/languages/golfscript/golfscript.test.md
@@ -10,7 +10,8 @@ print "b";
 ```
 
 ```golfscript nogolf
-1 n 2"a
+1"
+"+2"a
 ""b"
 ```
 
@@ -115,7 +116,8 @@ for $i 5 80 5 {
 ```
 
 ```golfscript nogolf
-80,5>5%{:i;i n}%
+80,5>5%{:i;i"
+"+}%
 ```
 
 ```polygolf
@@ -125,7 +127,8 @@ for $i -5 31 {
 ```
 
 ```golfscript nogolf
-36,{5-:i;i n}%
+36,{5-:i;i"
+"+}%
 ```
 
 ```polygolf
@@ -136,7 +139,8 @@ for $i $a ($a+6) {
 ```
 
 ```golfscript nogolf
--4:a;6,{a+:i;i n}%
+-4:a;6,{a+:i;i"
+"+}%
 ```
 
 ```polygolf
@@ -156,7 +160,8 @@ println (argv_get 5);
 ```
 
 ```golfscript nogolf
-:a;a 5=n
+:a;a 5="
+"+
 ```
 
 ```polygolf
@@ -166,5 +171,6 @@ for_argv $x 100 {
 ```
 
 ```golfscript nogolf
-:a;a{:x;x n}%
+:a;a{:x;x"
+"+}%
 ```

--- a/src/languages/golfscript/golfscript.test.md
+++ b/src/languages/golfscript/golfscript.test.md
@@ -10,7 +10,8 @@ print "b";
 ```
 
 ```golfscript nogolf
-1 n 2"a"n"b"
+1 n 2"a
+""b"
 ```
 
 ```polygolf

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -68,13 +68,7 @@ const golfscriptLanguage: Language = {
   emitter: emitProgram,
   phases: [
     search(hardcode()),
-    required(
-      printIntToPrint,
-      implicitlyConvertPrintArg,
-      printLnToPrint,
-      printConcatToMultiPrint,
-      printToImplicitOutput,
-    ),
+    required(printIntToPrint),
     search(
       flipBinaryOps,
       equalityToInequality,
@@ -100,8 +94,11 @@ const golfscriptLanguage: Language = {
           !isSubtype(getType(node.start, spine.root.node), integerType(0)),
       ),
       replaceToSplitAndJoin,
+      implicitlyConvertPrintArg,
+      printLnToPrint,
     ),
     simplegolf(
+      printConcatToMultiPrint,
       useBuiltinAliases({ "\n": "n" }),
       alias({
         Integer: (x) => x.value.toString(),
@@ -171,6 +168,9 @@ const golfscriptLanguage: Language = {
         text_byte_reversed: (x) => infix("%", x[0], int(-1)),
         int_to_text_byte: (x) => infix("+", list(x), text("")),
       }),
+    ),
+    required(
+      printToImplicitOutput,
       addImports({ a: "a" }, (x) =>
         x.length > 0 ? assignment("a", builtin("")) : undefined,
       ),

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -133,7 +133,6 @@ const golfscriptLanguage: Language = {
             ...(isIntLiteral()(x[0]) ? [add1(x[0]), x[1]] : [x[0], sub1(x[1])]),
           ),
       }),
-      mapOps({ print: (x) => x[0] }),
       mapToPrefixAndInfix({
         not: "!",
         bit_not: "~",

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -29,8 +29,13 @@ import {
   removeImplicitConversions,
   printIntToPrint,
 } from "../../plugins/ops";
-import { alias, renameIdents } from "../../plugins/idents";
-import { golfLastPrint, implicitlyConvertPrintArg } from "../../plugins/print";
+import { alias, renameIdents, useBuiltinAliases } from "../../plugins/idents";
+import {
+  implicitlyConvertPrintArg,
+  printConcatToMultiPrint,
+  printLnToPrint,
+  printToImplicitOutput,
+} from "../../plugins/print";
 import {
   forArgvToForEach,
   forRangeToForDifferenceRange,
@@ -63,10 +68,15 @@ const golfscriptLanguage: Language = {
   emitter: emitProgram,
   phases: [
     search(hardcode()),
-    required(printIntToPrint),
+    required(
+      printIntToPrint,
+      implicitlyConvertPrintArg,
+      printLnToPrint,
+      printConcatToMultiPrint,
+      printToImplicitOutput,
+    ),
     search(
       flipBinaryOps,
-      golfLastPrint(),
       equalityToInequality,
       ...bitnotPlugins,
       ...powPlugins,
@@ -89,8 +99,8 @@ const golfscriptLanguage: Language = {
         (node, spine) =>
           !isSubtype(getType(node.start, spine.root.node), integerType(0)),
       ),
-      implicitlyConvertPrintArg,
       replaceToSplitAndJoin,
+      useBuiltinAliases({ "\n": "n" }),
     ),
     simplegolf(
       alias({
@@ -125,7 +135,6 @@ const golfscriptLanguage: Language = {
       }),
       mapOps({ print: (x) => x[0] }),
       mapToPrefixAndInfix({
-        println: "n",
         not: "!",
         bit_not: "~",
         mul: "*",

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -104,7 +104,6 @@ const golfscriptLanguage: Language = {
         argv: builtin("a"),
         true: int(1),
         false: int(0),
-        print: (x) => x[0],
 
         text_get_byte_slice: (x) =>
           rangeIndexCall(x[0], x[1], add1(x[2]), int(1)),
@@ -124,6 +123,7 @@ const golfscriptLanguage: Language = {
             ...(isIntLiteral()(x[0]) ? [add1(x[0]), x[1]] : [x[0], sub1(x[1])]),
           ),
       }),
+      mapOps({ print: (x) => x[0] }),
       mapToPrefixAndInfix({
         println: "n",
         not: "!",

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -100,9 +100,9 @@ const golfscriptLanguage: Language = {
           !isSubtype(getType(node.start, spine.root.node), integerType(0)),
       ),
       replaceToSplitAndJoin,
-      useBuiltinAliases({ "\n": "n" }),
     ),
     simplegolf(
+      useBuiltinAliases({ "\n": "n" }),
       alias({
         Integer: (x) => x.value.toString(),
         Text: (x) => `"${x.value}"`,

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -8,8 +8,11 @@ import {
   type Identifier,
   type IR,
   isUserIdent,
+  type Node,
   type NodeFuncRecord,
   getNodeFunc,
+  isText,
+  builtin,
 } from "../IR";
 
 function getIdentMap(
@@ -133,5 +136,13 @@ export function alias(
       }, false).node;
       return block([...assignments, replacedDeep]);
     },
+  };
+}
+
+export function useBuiltinAliases(builtins: Record<string, string>) {
+  return function (node: Node) {
+    if (isText()(node) && node.value in builtins) {
+      return builtin(builtins[node.value]);
+    }
   };
 }

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -49,3 +49,16 @@ export function implicitlyConvertPrintArg(node: Node, spine: Spine) {
     return implicitConversion(node.op, node.args[0]);
   }
 }
+
+export const printToImplicitOutput = mapOps(
+  {
+    print: (x) => x[0],
+  },
+  "printToImplicitOutput",
+);
+
+export function printConcatToMultiPrint(node: Node, spine: Spine) {
+  if (isOp("print")(node) && isOp("concat")(node.args[0])) {
+    return block(node.args[0].args.map((x) => op("print", x)));
+  }
+}

--- a/src/programs/code.golf-default.test.md
+++ b/src/programs/code.golf-default.test.md
@@ -22,7 +22,8 @@ for_argv $arg 1000 {
 _Golfscript_
 
 ```gs
-:a;"Hello, World!"n 10,{:i;i n}%a{:A;A n}%
+:a;"Hello, World!
+"10,{:i;i n}%a{:A;A n}%
 ```
 
 _Lua_


### PR DESCRIPTION
The print mapOps replacement was clashing with other replacements in the same mapOps, fixes this. Causes cover to correctly recognize that gs has `argv_get`.