### PR TITLE
Typesafe op arity

### DIFF
--- a/docs/opcodes.generated.md
+++ b/docs/opcodes.generated.md
@@ -3,20 +3,20 @@ Hover opcode name to see a description.
 
 | Alias | Full name | Input | Output |
 |-------|-----------|-------|--------|
-| + | [add](## "Integer addition.") | [...Int] | ? |
+| + | [add](## "Integer addition.") | [Int, Int, ...Int] | Int |
 | - | [sub](## "Integer subtraction.")<br>[neg](## "Integer negation.") | [Int, Int]<br>[Int] | Int<br>Int |
-| * | [mul](## "Integer multiplication.") | [...Int] | ? |
+| * | [mul](## "Integer multiplication.") | [Int, Int, ...Int] | Int |
 | div | [div](## "Integer floor division.") | [Int, Int] | Int |
 | ^ | [pow](## "Integer exponentiation.") | [Int, 0..oo] | Int |
 | mod | [mod](## "Integer modulo (corresponds to `div`).") | [Int, Int] | Int |
-| & | [bit_and](## "Integer bitwise and.") | [...Int] | ? |
-| \| | [bit_or](## "Integer bitwise or.") | [...Int] | ? |
-| ~ | [bit_xor](## "Integer bitwise xor.")<br>[bit_not](## "Integer bitwise not.") | [...Int]<br>[Int] | ?<br>Int |
+| & | [bit_and](## "Integer bitwise and.") | [Int, Int, ...Int] | Int |
+| \| | [bit_or](## "Integer bitwise or.") | [Int, Int, ...Int] | Int |
+| ~ | [bit_xor](## "Integer bitwise xor.")<br>[bit_not](## "Integer bitwise not.") | [Int, Int, ...Int]<br>[Int] | Int<br>Int |
 | << | [bit_shift_left](## "Integer left bitshift.") | [Int, 0..oo] | Int |
 | >> | [bit_shift_right](## "Integer arithmetic right bitshift.") | [Int, 0..oo] | Int |
-| gcd | [gcd](## "Greatest common divisor of two integers.") | [...Int] | ? |
-| min | [min](## "Integer minimum.") | [...Int] | ? |
-| max | [max](## "Integer maximum.") | [...Int] | ? |
+| gcd | [gcd](## "Greatest common divisor of two integers.") | [Int, Int, ...Int] | 1..oo |
+| min | [min](## "Integer minimum.") | [Int, Int, ...Int] | Int |
+| max | [max](## "Integer maximum.") | [Int, Int, ...Int] | Int |
 | abs | [abs](## "Integer absolute value.") | [Int] | 0..oo |
 | read[line] | [read[line]](## "Reads single line from the stdin.") | [] | Text |
 | @ | [at[argv]](## "Gets argv at the 0-based `n`th position, where `n` is an integer literal.")<br>[at[Array]](## "Gets the item at the 0-based index.")<br>[at[List]](## "Gets the item at the 0-based index.")<br>[at_back[List]](## "Gets the item at the -1-based backwards index.")<br>[at[Table]](## "Gets the item at the key.")<br>[at[Ascii]](## "Gets the character at the 0-based index.")<br>[at_back[Ascii]](## "Gets the character at the -1-based backwards index.") | [0..oo]<br>[(Array T1 T2), T2]<br>[(List T1), 0..oo]<br>[(List T1), -oo..-1]<br>[(Table T1 T2), T1]<br>[Ascii, 0..oo]<br>[Ascii, -oo..-1] | Text<br>T1<br>T1<br>T1<br>T2<br>(Ascii 1..1)<br>(Ascii 1..1) |
@@ -25,8 +25,8 @@ Hover opcode name to see a description.
 | putc[byte] | [putc[byte]](## "Creates a single byte text and prints it.") | [0..255] | Void |
 | putc[codepoint] | [putc[codepoint]](## "Creates a single codepoint text and prints it.") | [0..1114111] | Void |
 | putc | [putc[Ascii]](## "Creates a single ascii character text and prints it.") | [0..127] | Void |
-| or | [or](## "Non-shortcircuiting logical or. All arguments are to be safely evaluated in any order.") | [...Bool] | Bool |
-| and | [and](## "Non-shortcircuiting logical and. All arguments are to be safely evaluated in any order.") | [...Bool] | Bool |
+| or | [or](## "Non-shortcircuiting logical or. All arguments are to be safely evaluated in any order.") | [Bool, Bool, ...Bool] | Bool |
+| and | [and](## "Non-shortcircuiting logical and. All arguments are to be safely evaluated in any order.") | [Bool, Bool, ...Bool] | Bool |
 | unsafe_or | [unsafe_or](## "Shortcircuiting logical or.") | [Bool, Bool] | Bool |
 | unsafe_and | [unsafe_and](## "Shortcircuiting logical and.") | [Bool, Bool] | Bool |
 | not | [not](## "Logical not.") | [Bool] | Bool |

--- a/docs/opcodes.generated.md
+++ b/docs/opcodes.generated.md
@@ -3,20 +3,20 @@ Hover opcode name to see a description.
 
 | Alias | Full name | Input | Output |
 |-------|-----------|-------|--------|
-| + | [add](## "Integer addition.") | [...Int] | Int |
+| + | [add](## "Integer addition.") | [...Int] | ? |
 | - | [sub](## "Integer subtraction.")<br>[neg](## "Integer negation.") | [Int, Int]<br>[Int] | Int<br>Int |
-| * | [mul](## "Integer multiplication.") | [...Int] | Int |
+| * | [mul](## "Integer multiplication.") | [...Int] | ? |
 | div | [div](## "Integer floor division.") | [Int, Int] | Int |
 | ^ | [pow](## "Integer exponentiation.") | [Int, 0..oo] | Int |
 | mod | [mod](## "Integer modulo (corresponds to `div`).") | [Int, Int] | Int |
-| & | [bit_and](## "Integer bitwise and.") | [...Int] | Int |
-| \| | [bit_or](## "Integer bitwise or.") | [...Int] | Int |
-| ~ | [bit_xor](## "Integer bitwise xor.")<br>[bit_not](## "Integer bitwise not.") | [...Int]<br>[Int] | Int<br>Int |
+| & | [bit_and](## "Integer bitwise and.") | [...Int] | ? |
+| \| | [bit_or](## "Integer bitwise or.") | [...Int] | ? |
+| ~ | [bit_xor](## "Integer bitwise xor.")<br>[bit_not](## "Integer bitwise not.") | [...Int]<br>[Int] | ?<br>Int |
 | << | [bit_shift_left](## "Integer left bitshift.") | [Int, 0..oo] | Int |
 | >> | [bit_shift_right](## "Integer arithmetic right bitshift.") | [Int, 0..oo] | Int |
-| gcd | [gcd](## "Greatest common divisor of two integers.") | [...Int] | 1..oo |
-| min | [min](## "Integer minimum.") | [...Int] | Int |
-| max | [max](## "Integer maximum.") | [...Int] | Int |
+| gcd | [gcd](## "Greatest common divisor of two integers.") | [...Int] | ? |
+| min | [min](## "Integer minimum.") | [...Int] | ? |
+| max | [max](## "Integer maximum.") | [...Int] | ? |
 | abs | [abs](## "Integer absolute value.") | [Int] | 0..oo |
 | read[line] | [read[line]](## "Reads single line from the stdin.") | [] | Text |
 | @ | [at[argv]](## "Gets argv at the 0-based `n`th position, where `n` is an integer literal.")<br>[at[Array]](## "Gets the item at the 0-based index.")<br>[at[List]](## "Gets the item at the 0-based index.")<br>[at_back[List]](## "Gets the item at the -1-based backwards index.")<br>[at[Table]](## "Gets the item at the key.")<br>[at[Ascii]](## "Gets the character at the 0-based index.")<br>[at_back[Ascii]](## "Gets the character at the -1-based backwards index.") | [0..oo]<br>[(Array T1 T2), T2]<br>[(List T1), 0..oo]<br>[(List T1), -oo..-1]<br>[(Table T1 T2), T1]<br>[Ascii, 0..oo]<br>[Ascii, -oo..-1] | Text<br>T1<br>T1<br>T1<br>T2<br>(Ascii 1..1)<br>(Ascii 1..1) |
@@ -67,7 +67,7 @@ Hover opcode name to see a description.
 | size[byte] | [size[byte]](## "Returns the length of the text in bytes.") | [Text] | 0..2147483648 |
 | include | [include](## "Modifies the set by including the given item.") | [(Set T1), T1] | Void |
 | push | [push](## "Modifies the list by pushing the given item at the end.") | [(List T1), T1] | Void |
-| .. | [append](## "Returns a new list with the given item appended at the end.")<br>[concat[List]](## "Returns a new list formed by concatenation of the inputs.")<br>[concat[Text]](## "Returns a new text formed by concatenation of the inputs.") | [(List T1), T1]<br>[...(List T1)]<br>[...Text] | (List T1)<br>(List T1)<br>Text |
+| .. | [append](## "Returns a new list with the given item appended at the end.")<br>[concat[List]](## "Returns a new list formed by concatenation of the inputs.")<br>[concat[Text]](## "Returns a new text formed by concatenation of the inputs.") | [(List T1), T1]<br>[...(List T1)]<br>[...Text] | (List T1)<br>?<br>? |
 | repeat | [repeat](## "Repeats the text a given amount of times.") | [Text, 0..oo] | Text |
 | split | [split](## "Splits the text by the delimiter.") | [Text, Text] | (List Text) |
 | split_whitespace | [split_whitespace](## "Splits the text by any whitespace.") | [Text] | (List Text) |

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -25,7 +25,10 @@ import {
   inverseOpCode,
   type OpCodeArgValues,
   isUnary,
+  opCodeDefinitions,
+  isNullary,
 } from "./IR";
+import { mapObjectValues } from "../common/arrays";
 
 export interface ImplicitConversion extends BaseNode {
   readonly kind: "ImplicitConversion";
@@ -160,6 +163,21 @@ export function keyValue(key: Node, value: Node): KeyValue {
 }
 
 /**
+ * This object contains contructors for each opcode, with signatures
+ * validating the arities.
+ */
+export const op = {
+  ...(mapObjectValues(opCodeDefinitions, (v, k) =>
+    isNullary(k) ? opUnsafe(k) : (...x: Node[]) => opUnsafe(k, ...x),
+  ) as {
+    [O in OpCode]: OpCodeArgValues<O> extends readonly []
+      ? Op<O>
+      : (...args: OpCodeArgValues<O>) => Op<O>;
+  }),
+  unsafe: opUnsafe,
+} as const;
+
+/**
  * This assumes that the construction will not break the invariants described
  * on `Op` interface and hence is made private.
  */
@@ -171,7 +189,11 @@ function _op(op: OpCode, ...args: Node[]): Op {
   };
 }
 
-export function op(opCode: OpCode, ...args: Node[]): Node {
+/**
+ * This is the implementation respecting the invariants described on the `Op`
+ * interface, but it doesn't validate arity.
+ */
+function opUnsafe(opCode: OpCode, ...args: Node[]): Node {
   if (!isOpCode(opCode)) return _op(opCode, ...args);
   if (isUnary(opCode)) {
     const value = evalUnary(opCode, args[0]);
@@ -184,7 +206,7 @@ export function op(opCode: OpCode, ...args: Node[]): Node {
         return arg.args[0]!;
       if (opCode === "not") {
         if (arg.op in booleanNotOpCode) {
-          return op(
+          return op.unsafe(
             booleanNotOpCode[arg.op as keyof typeof booleanNotOpCode],
             arg.args[0]!,
             arg.args[1]!,
@@ -204,10 +226,10 @@ export function op(opCode: OpCode, ...args: Node[]): Node {
     if (isInt()(args[0])) {
       return int(-args[0].value);
     }
-    return op("mul", int(-1), args[0]);
+    return op.mul(int(-1), args[0]);
   }
   if (opCode === "sub") {
-    return op("add", args[0], op("neg", args[1]));
+    return op.add(args[0], op.neg(args[1]));
   }
   if (isAssociative(opCode)) {
     args = args.flatMap((x) => (isOp(opCode)(x) ? x.args : [x]));
@@ -247,7 +269,7 @@ export function op(opCode: OpCode, ...args: Node[]): Node {
             isInt()(x)
               ? int(-x.value)
               : x === toNegate
-              ? op("add", ...(x as Op).args.map((y) => op("neg", y)))
+              ? op.unsafe("add", ...(x as Op).args.map(op.neg))
               : x,
           );
         }
@@ -355,8 +377,8 @@ function simplifyPolynomial(terms: Node[]): Node[] {
   return result;
 }
 
-export const add1 = (expr: Node) => op("add", expr, int(1n));
-export const sub1 = (expr: Node) => op("add", expr, int(-1n));
+export const succ = (expr: Node) => op.add(expr, int(1n));
+export const prec = (expr: Node) => op.add(expr, int(-1n));
 
 export function functionCall(
   func: string | Node,
@@ -473,7 +495,7 @@ export function namedArg<T extends Node>(name: string, value: T): NamedArg<T> {
 }
 
 export function print(value: Node, newline: boolean = true): Node {
-  return op(newline ? "println[Text]" : "print[Text]", value);
+  return op[newline ? "println[Text]" : "print[Text]"](value);
 }
 
 export function getArgs(

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -167,8 +167,16 @@ export function keyValue(key: Node, value: Node): KeyValue {
  * validating the arities.
  */
 export const op = {
-  ...(mapObjectValues(opCodeDefinitions, (v, k) =>
-    isNullary(k) ? opUnsafe(k) : (...x: Node[]) => opUnsafe(k, ...x),
+  ...(mapObjectValues(
+    opCodeDefinitions,
+    (v, k) =>
+      isNullary(k)
+        ? opUnsafe(k)
+        : (...x: Node[]) =>
+            opUnsafe(
+              k,
+              ...x.filter((x) => typeof x === "object" && "kind" in x),
+            ), // allow unary opcodes to be used in map
   ) as {
     [O in OpCode]: OpCodeArgValues<O> extends readonly []
       ? Op<O>

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -23,7 +23,7 @@ import {
   isCommutative,
   isOpCode,
   inverseOpCode,
-  OpCodeArgValues,
+  type OpCodeArgValues,
   isUnary,
 } from "./IR";
 

--- a/src/IR/exprs.ts
+++ b/src/IR/exprs.ts
@@ -22,6 +22,7 @@ import {
   isCommutative,
   isOpCode,
   inverseOpCode,
+  OpCodeArgValues,
 } from "./IR";
 
 export interface ImplicitConversion extends BaseNode {
@@ -50,7 +51,7 @@ export interface ImplicitConversion extends BaseNode {
 export interface Op<Op extends OpCode = OpCode> extends BaseNode {
   readonly kind: "Op";
   readonly op: Op;
-  readonly args: readonly Node[];
+  readonly args: OpCodeArgValues<Op>;
 }
 
 export interface KeyValue extends BaseNode {
@@ -173,14 +174,14 @@ export function op(opCode: OpCode, ...args: Node[]): Node {
   if (opCode === "not" || opCode === "bit_not") {
     const arg = args[0];
     if (isOp()(arg)) {
-      if (arg.op === opCode && arg.args[0].kind !== "ImplicitConversion")
-        return arg.args[0];
+      if (arg.op === opCode && arg.args[0]?.kind !== "ImplicitConversion")
+        return arg.args[0]!;
       if (opCode === "not") {
         if (arg.op in booleanNotOpCode) {
           return op(
             booleanNotOpCode[arg.op as keyof typeof booleanNotOpCode],
-            arg.args[0],
-            arg.args[1],
+            arg.args[0]!,
+            arg.args[1]!,
           );
         }
       }

--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -493,8 +493,8 @@ export function arity(op: OpCode): number {
 
 export function matchesOpCodeArity(op: OpCode, arity: number) {
   const expectedTypes = opCodeDefinitions[op].args;
-  if ("variadic" in expectedTypes) {
-    return arity >= expectedTypes.min;
+  if (expectedTypes.length > 0 && "variadic" in expectedTypes.at(-1)!) {
+    return arity >= expectedTypes.length - 1;
   }
   return expectedTypes.length === arity;
 }

--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -508,7 +508,7 @@ export function userName(opCode: OpCode) {
 export function arity(op: OpCode): number {
   try {
     const args = opCodeDefinitions[op].args;
-    if ("variadic" in args) return -1;
+    if (args.length > 0 && "res" in args.at(-1)!) return -1;
     return args.length;
   } catch (e) {
     console.log("arity of", op);
@@ -518,7 +518,7 @@ export function arity(op: OpCode): number {
 
 export function matchesOpCodeArity(op: OpCode, arity: number) {
   const expectedTypes = opCodeDefinitions[op].args;
-  if (expectedTypes.length > 0 && "variadic" in expectedTypes.at(-1)!) {
+  if (expectedTypes.length > 0 && "rest" in expectedTypes.at(-1)!) {
     return arity >= expectedTypes.length - 1;
   }
   return expectedTypes.length === arity;

--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -32,11 +32,13 @@ function rest<T extends Type>(rest: T): Rest<T> {
 const T1 = typeArg("T1");
 const T2 = typeArg("T2");
 
+const int2OrMore = [int(), int(), rest(int())] as const;
+const bool2OrMore = [bool, bool, rest(bool)] as const;
 export const opCodeDefinitions = {
   // Arithmetic
-  add: { args: [rest(int())], front: "+", assoc: true, commutes: true },
+  add: { args: int2OrMore, front: "+", assoc: true, commutes: true },
   sub: { args: [int(), int()], front: "-" },
-  mul: { args: [rest(int())], front: "*", assoc: true, commutes: true },
+  mul: { args: int2OrMore, front: "*", assoc: true, commutes: true },
   div: { args: [int(), int()], front: "div" },
   trunc_div: { args: [int(), int()] },
   unsigned_trunc_div: { args: [int(), int()] },
@@ -44,14 +46,14 @@ export const opCodeDefinitions = {
   mod: { args: [int(), int()], front: "mod" },
   rem: { args: [int(), int()] },
   unsigned_rem: { args: [int(), int()] },
-  bit_and: { args: [rest(int())], front: "&", assoc: true, commutes: true },
-  bit_or: { args: [rest(int())], front: "|", assoc: true, commutes: true },
-  bit_xor: { args: [rest(int())], front: "~", assoc: true, commutes: true },
+  bit_and: { args: int2OrMore, front: "&", assoc: true, commutes: true },
+  bit_or: { args: int2OrMore, front: "|", assoc: true, commutes: true },
+  bit_xor: { args: int2OrMore, front: "~", assoc: true, commutes: true },
   bit_shift_left: { args: [int(), int(0)], front: "<<" },
   bit_shift_right: { args: [int(), int(0)], front: ">>" },
-  gcd: { args: [rest(int())], front: true, assoc: true, commutes: true },
-  min: { args: [rest(int())], front: true, assoc: true, commutes: true },
-  max: { args: [rest(int())], front: true, assoc: true, commutes: true },
+  gcd: { args: int2OrMore, front: true, assoc: true, commutes: true },
+  min: { args: int2OrMore, front: true, assoc: true, commutes: true },
+  max: { args: int2OrMore, front: true, assoc: true, commutes: true },
   neg: { args: [int()], front: "-" },
   abs: { args: [int()], front: true },
   bit_not: { args: [int()], front: "~" },
@@ -77,8 +79,8 @@ export const opCodeDefinitions = {
   "putc[Ascii]": { args: [int(0, 127)], front: "putc" },
 
   // Bool arithmetic
-  or: { args: [rest(bool)], front: true, assoc: true, commutes: true },
-  and: { args: [rest(bool)], front: true, assoc: true, commutes: true },
+  or: { args: bool2OrMore, front: true, assoc: true, commutes: true },
+  and: { args: bool2OrMore, front: true, assoc: true, commutes: true },
   unsafe_or: { args: [bool, bool], front: true, assoc: true },
   unsafe_and: { args: [bool, bool], front: true },
   not: { args: [bool], front: true },
@@ -508,7 +510,7 @@ export function userName(opCode: OpCode) {
 export function arity(op: OpCode): number {
   try {
     const args = opCodeDefinitions[op].args;
-    if (args.length > 0 && "res" in args.at(-1)!) return -1;
+    if (args.length > 0 && "rest" in args.at(-1)!) return -1;
     return args.length;
   } catch (e) {
     console.log("arity of", op);

--- a/src/IR/opcodes.ts
+++ b/src/IR/opcodes.ts
@@ -1,4 +1,4 @@
-import { Node } from "./IR";
+import type { Node } from "./IR";
 import {
   type Type,
   typeArg,
@@ -19,7 +19,7 @@ interface OpCodeDefinition {
   commutes?: true;
 }
 
-interface Rest<T extends Type = Type> {
+export interface Rest<T extends Type = Type> {
   rest: T;
 }
 export type AnyOpCodeArgTypes =

--- a/src/IR/types.ts
+++ b/src/IR/types.ts
@@ -572,7 +572,7 @@ export function getLiteralOfType(type: Type, nonEmpty = false): Node {
           : (type.low as bigint),
       );
     case "boolean":
-      return op("true");
+      return op.true;
     case "Array":
       if (isArrayIndexType(type.length))
         return array(

--- a/src/common/Spine.ts
+++ b/src/common/Spine.ts
@@ -78,7 +78,7 @@ export class Spine<N extends IR.Node = IR.Node> {
         ? this.parent.replacedWith(
             {
               ...(isOp()(parentNode)
-                ? op(
+                ? op.unsafe(
                     parentNode.op,
                     ...replaceAtIndex(
                       parentNode.args,
@@ -183,7 +183,7 @@ export class Spine<N extends IR.Node = IR.Node> {
         if (someChildrenIsNew)
           curr = curr.replacedWith({
             ...(isOp()(this.node)
-              ? op(this.node.op, ...newChildren)
+              ? op.unsafe(this.node.op, ...newChildren)
               : block(newChildren)),
             targetType: this.node.targetType,
           });

--- a/src/common/compile.test.ts
+++ b/src/common/compile.test.ts
@@ -17,7 +17,7 @@ const textLang: Language = {
   emitter(program, context) {
     return (program.kind === "Block" ? program.children : [program]).map(
       (x) => {
-        if (isOp()(x) && isText()(x.args[0])) {
+        if (isOp()(x) && x.args.length > 0 && isText()(x.args[0]!)) {
           if (x.args[0].value.endsWith("X")) {
             context.addWarning(new PolygolfError("global warning"), true);
             context.addWarning(

--- a/src/common/compile.ts
+++ b/src/common/compile.ts
@@ -582,7 +582,7 @@ export function typecheck(program: Node, everyNode = true): Node {
     if (everyNode || (node.kind === "Op" && !isOpCode(node.op))) {
       const t = getTypeAndResolveOpCode(node, spine);
       if (isOp()(node) && t.opCode !== undefined) {
-        return op(t.opCode, ...node.args);
+        return op.unsafe(t.opCode, ...node.args);
       }
     }
   }).node;

--- a/src/common/getType.test.ts
+++ b/src/common/getType.test.ts
@@ -154,7 +154,7 @@ describe("Assignment", () => {
   );
   test("Self-referential assignment", () => {
     const aLHS = id("a");
-    const expr = assignment(aLHS, op("add", id("a"), e(int(1))));
+    const expr = assignment(aLHS, op.add(id("a"), e(int(1))));
     expect(() => calcTypeAndResolveOpCode(aLHS, block([expr]))).toThrow(
       PolygolfError,
     );
@@ -174,8 +174,8 @@ describe("Literals", () => {
   testNode("int", intNode(4n), int(4, 4));
   testNode("text", textNode("ahoj"), ascii(int(4, 4)));
   testNode("text", textNode("dobrý den"), text(int(9, 9)));
-  testNode("bool", op("true"), bool);
-  testNode("bool", op("false"), bool);
+  testNode("bool", op.true, bool);
+  testNode("bool", op.false, bool);
   testNode("array", arrayNode([e(int()), e(text())]), "error");
   testNode(
     "array",

--- a/src/common/getType.ts
+++ b/src/common/getType.ts
@@ -45,7 +45,7 @@ import {
   type ArrayType,
   type TableType,
   opCodeDefinitions,
-  type ArgTypes,
+  type AnyOpCodeArgTypes,
   OpCodeFrontNamesToOpCodes,
   integerType,
 } from "../IR";
@@ -252,7 +252,7 @@ export function getInstantiatedOpCodeArgTypes(op: OpCode): Type[] {
   if (!("variadic" in type)) {
     return type.map(instantiate);
   }
-  return Array(type.min).fill(instantiate(type.variadic));
+  return Array(type.min).fill(instantiate(type.rest));
 }
 
 export function getGenericOpCodeArgTypes(op: OpCode): Type[] {
@@ -260,10 +260,12 @@ export function getGenericOpCodeArgTypes(op: OpCode): Type[] {
   if (!("variadic" in type)) {
     return [...type];
   }
-  return Array(type.min).fill(type.variadic);
+  return Array(type.min).fill(type.rest);
 }
 
-export function expectedTypesToString(expectedTypes: ArgTypes): string {
+export function expectedTypesToString(
+  expectedTypes: AnyOpCodeArgTypes,
+): string {
   return "variadic" in expectedTypes
     ? `[...${toString(expectedTypes.variadic)}]`
     : `[${expectedTypes.map(toString).join(", ")}]`;
@@ -276,7 +278,7 @@ export function expectedTypesToString(expectedTypes: ArgTypes): string {
  * @param expectedTypes Expected types (array of types or variadic object).
  * @returns True iff it is a match.
  */
-function isTypeMatch(gotTypes: Type[], expectedTypes: ArgTypes) {
+function isTypeMatch(gotTypes: Type[], expectedTypes: AnyOpCodeArgTypes) {
   const variadic = "variadic" in expectedTypes;
   if (variadic && expectedTypes.min > gotTypes.length) return false;
   if (!variadic && expectedTypes.length !== gotTypes.length) return false;

--- a/src/common/getType.ts
+++ b/src/common/getType.ts
@@ -237,7 +237,7 @@ export function calcTypeAndResolveOpCode(
     case "ForDifferenceRange":
       return voidType;
     case "ImplicitConversion": {
-      return type(op(expr.behavesLike, expr.expr));
+      return type(op.unsafe(expr.behavesLike, expr.expr));
     }
   }
   throw new Error(`Type error. Unexpected node ${stringify(expr)}.`);

--- a/src/cover/index.ts
+++ b/src/cover/index.ts
@@ -70,14 +70,14 @@ function nextBuiltin(x: Type) {
 
 for (const lang of langs) {
   const compilesAssignment = isCompilable(assignment(id("x"), int(0)), lang);
-  const compilesPrintInt = isCompilable(op("print[Int]", int(0)), lang);
-  const compilesPrint = isCompilable(op("print[Text]", text("x")), lang);
+  const compilesPrintInt = isCompilable(op["print[Int]"](int(0)), lang);
+  const compilesPrint = isCompilable(op["print[Text]"](text("x")), lang);
 
   lang.stmt = function (x: Node | undefined) {
     x ??= compilesPrintInt ? int(0) : text("x");
     const type = getType(x, x);
-    if (compilesPrint && type.kind === "text") return op("print[Text]", x);
-    if (compilesPrintInt && type.kind === "integer") return op("print[Int]", x);
+    if (compilesPrint && type.kind === "text") return op["print[Text]"](x);
+    if (compilesPrintInt && type.kind === "integer") return op["print[Int]"](x);
     if (compilesAssignment) return assignment(id("x"), x);
     return x;
   };
@@ -185,7 +185,7 @@ const opCodes: CoverTableRecipe = Object.fromEntries(
     opCode,
     (lang) =>
       lang.stmt(
-        op(
+        op.unsafe(
           opCode,
           ...getInstantiatedOpCodeArgTypes(opCode).map((x) =>
             lang.expr(x, opCode.startsWith("set_") || opCode === "push"),
@@ -207,7 +207,7 @@ if (options.all === true) {
           opCode,
           (lang) =>
             lang.stmt(
-              op(
+              op.unsafe(
                 opCode,
                 ...getInstantiatedOpCodeArgTypes(opCode).map((x) =>
                   lang.expr(x),

--- a/src/frontend/parse.test.ts
+++ b/src/frontend/parse.test.ts
@@ -49,8 +49,8 @@ describe("Parse literals", () => {
 });
 
 describe("Parse s-expressions", () => {
-  expectExprParse("true nullary op", "true", op("true"));
-  expectExprParse("argv nullary op", "argv", op("argv"));
+  expectExprParse("true nullary op", "true", op.true);
+  expectExprParse("argv nullary op", "argv", op.argv);
   expectExprParse(
     "user function",
     "($f 1 2)",
@@ -61,10 +61,10 @@ describe("Parse s-expressions", () => {
     "($f $x $y)",
     functionCall(id("f"), id("x"), id("y")),
   );
-  expectExprParse("add", "(add $x $y)", op("add", id("x"), id("y")));
-  expectExprParse("add infix", "($x + $y)", op("add", id("x"), id("y")));
-  expectExprParse("mod infix", "($x mod $y)", op("mod", id("x"), id("y")));
-  expectExprParse("or", "(or $x $y)", op("or", id("x"), id("y")));
+  expectExprParse("add", "(add $x $y)", op.add(id("x"), id("y")));
+  expectExprParse("add infix", "($x + $y)", op.add(id("x"), id("y")));
+  expectExprParse("mod infix", "($x mod $y)", op.mod(id("x"), id("y")));
+  expectExprParse("or", "(or $x $y)", op.or(id("x"), id("y")));
   expectExprParse("println[Text]", "(println[Text] $x)", print(id("x"), true));
   expectExprParse("print[Text]", "(print[Text] $x)", print(id("x"), false));
   expectExprParse("assign", "(assign $x 5)", assignment(id("x"), int(5n)));
@@ -73,17 +73,17 @@ describe("Parse s-expressions", () => {
   expectExprParse(
     "+",
     "(+ $x $y $z $w)",
-    op("add", op("add", op("add", id("x"), id("y")), id("z")), id("w")),
+    op.add(id("x"), id("y"), id("z"), id("w")),
   );
   expectExprParse(
     "..",
     "(concat[Text] $x $y $z)",
-    op("concat[Text]", op("concat[Text]", id("x"), id("y")), id("z")),
+    op["concat[Text]"](id("x"), id("y"), id("z")),
   );
-  expectExprParse("- as neg", "(- $x)", op("neg", id("x")));
-  expectExprParse("- as sub", "(- $x $y)", op("sub", id("x"), id("y")));
-  expectExprParse("~ as bitnot", "(~ $x)", op("bit_not", id("x")));
-  expectExprParse("~ as bitxor", "(~ $x $y)", op("bit_xor", id("x"), id("y")));
+  expectExprParse("- as neg", "(- $x)", op.neg(id("x")));
+  expectExprParse("- as sub", "(- $x $y)", op.sub(id("x"), id("y")));
+  expectExprParse("~ as bitnot", "(~ $x)", op.bit_not(id("x")));
+  expectExprParse("~ as bitxor", "(~ $x $y)", op.bit_xor(id("x"), id("y")));
 });
 
 describe("Parse annotations", () => {
@@ -167,7 +167,7 @@ describe("Parse indexing asignment", () => {
   `,
     block([
       assignment("x", list([int(2), int(3)])),
-      op("set_at" as any, id("x"), int(0), int(3)),
+      op.unsafe("set_at" as any, id("x"), int(0), int(3)),
     ]),
   );
 });

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -413,10 +413,10 @@ export function sexpr(
   if (arityMatchingOpCodes.length > 1) {
     // Hack! We temporarily assign the front name to the opCode field.
     // It will be resolved during typecheck.
-    return op(callee as OpCode, ...args);
+    return op.unsafe(callee as OpCode, ...args);
   }
 
-  return op(arityMatchingOpCodes[0], ...args);
+  return op.unsafe(arityMatchingOpCodes[0], ...args);
 }
 
 function intValue(x: string): bigint {

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -401,7 +401,9 @@ export function sexpr(
         `Expected ${matchingOpCodes
           .map((opCode) => opCodeDefinitions[opCode].args)
           .map((args) =>
-            "variadic" in args ? `${args.min}..oo` : `${args.length}`,
+            args.length > 0 && "variadic" in args
+              ? `${args.length - 1}..oo`
+              : `${args.length}`,
           )
           .join(", ")} but got ${args.length}.`,
       calleeIdent.source,

--- a/src/frontend/parse.ts
+++ b/src/frontend/parse.ts
@@ -401,7 +401,7 @@ export function sexpr(
         `Expected ${matchingOpCodes
           .map((opCode) => opCodeDefinitions[opCode].args)
           .map((args) =>
-            args.length > 0 && "variadic" in args
+            args.length > 0 && "rest" in args.at(-1)!
               ? `${args.length - 1}..oo`
               : `${args.length}`,
           )

--- a/src/languages/golfscript/index.ts
+++ b/src/languages/golfscript/index.ts
@@ -3,8 +3,6 @@ import {
   integerType,
   isSubtype,
   rangeIndexCall,
-  add1,
-  sub1,
   builtin,
   op,
   int,
@@ -14,6 +12,8 @@ import {
   prefix,
   isInt,
   implicitConversion,
+  prec,
+  succ,
 } from "../../IR";
 import {
   defaultDetokenizer,
@@ -122,42 +122,36 @@ const golfscriptLanguage: Language = {
     ),
     required(
       mapOps({
-        "at[argv]": (x) => op("at[List]", op("argv"), x[0]),
+        "at[argv]": (x) => op["at[List]"](op.argv, x[0]),
         argv: builtin("a"),
         true: int(1),
         false: int(0),
 
         "slice[byte]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1)),
         "slice[List]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1)),
-        neg: (x) => op("mul", x[0], int(-1)),
-        max: (x) => op("at[List]", op("sorted[Int]", list(x)), int(1)),
-        min: (x) => op("at[List]", op("sorted[Int]", list(x)), int(0)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1)),
+        neg: (x) => op.mul(x[0], int(-1)),
+        max: (x) => op["at[List]"](op["sorted[Int]"](list(x)), int(1)),
+        min: (x) => op["at[List]"](op["sorted[Int]"](list(x)), int(0)),
 
         leq: (x) =>
-          op(
-            "lt",
-            ...(isInt()(x[0]) ? [sub1(x[0]), x[1]] : [x[0], add1(x[1])]),
-          ),
+          isInt()(x[0]) ? op.lt(prec(x[0]), x[1]) : op.lt(x[0], succ(x[1])),
 
         geq: (x) =>
-          op(
-            "gt",
-            ...(isInt()(x[0]) ? [add1(x[0]), x[1]] : [x[0], sub1(x[1])]),
-          ),
+          isInt()(x[0]) ? op.gt(succ(x[0]), x[1]) : op.gt(x[0], prec(x[1])),
         int_to_bool: (x) => implicitConversion("int_to_bool", x[0]),
         bool_to_int: (x) => implicitConversion("bool_to_int", x[0]),
-        append: (x) => op("concat[List]", x[0], list([x[1]])),
+        append: (x) => op["concat[List]"](x[0], list([x[1]])),
         "contains[Text]": (x) =>
           implicitConversion(
             "int_to_bool",
-            op("add", op("find[byte]", x[0], x[1]), int(1n)),
+            op.add(op["find[byte]"](x[0], x[1]), int(1n)),
           ),
         "contains[List]": (x) =>
           implicitConversion(
             "int_to_bool",
-            op("add", op("find[List]", x[0], x[1]), int(1n)),
+            op.add(op["find[List]"](x[0], x[1]), int(1n)),
           ),
         int_to_bin: (x) => infix("*", infix("base", x[0], int(2n)), text("")),
 
@@ -170,7 +164,7 @@ const golfscriptLanguage: Language = {
           ),
         gcd: (x) => infix("{.}{.@@%}while;", x[0], x[1]),
         split_whitespace: (x) =>
-          op("split", prefix("{...9<\\13>+*\\32if}%", x[0]), text(" ")),
+          op.split(prefix("{...9<\\13>+*\\32if}%", x[0]), text(" ")),
         right_align: (x) => infix('1$,-.0>*" "*\\+', x[0], x[1]),
         int_to_hex_aligned: (x) =>
           infix('16base{.9>7*+48+}%""+\\1$,-.0>*"0"*\\+', x[0], x[1]),

--- a/src/languages/janet/index.ts
+++ b/src/languages/janet/index.ts
@@ -17,7 +17,7 @@ import {
 } from "../../plugins/ops";
 import { addVarDeclarations } from "../../plugins/block";
 import {
-  add1,
+  succ,
   builtin,
   conditional,
   functionCall as func,
@@ -72,13 +72,13 @@ const janetLanguage: Language = {
         right_align: (x) =>
           func(
             "string/format",
-            op("concat[Text]", text("%"), op("int_to_dec", x[1]), text("s")),
+            op["concat[Text]"](text("%"), op.int_to_dec(x[1]), text("s")),
             x[0],
           ),
         int_to_hex_aligned: (x) =>
           func(
             "string/format",
-            op("concat[Text]", text("%0"), op("int_to_dec", x[1]), text("X")),
+            op["concat[Text]"](text("%0"), op.int_to_dec(x[1]), text("X")),
             x[0],
           ),
       }),
@@ -88,32 +88,32 @@ const janetLanguage: Language = {
       mapOps({
         argv: func("slice", func("dyn", builtin(":args")), int(1n)),
 
-        append: (x) => op("concat[List]", x[0], list([x[1]])),
+        append: (x) => op["concat[List]"](x[0], list([x[1]])),
 
         "at[argv]": (x) =>
-          op("at[List]", func("dyn", builtin(":args")), add1(x[0])),
-        "at[byte]": (x) => op("slice[byte]", x[0], x[1], int(1n)),
-        "contains[Text]": (x) => func("int?", op("find[byte]", x[0], x[1])),
+          op["at[List]"](func("dyn", builtin(":args")), succ(x[0])),
+        "at[byte]": (x) => op["slice[byte]"](x[0], x[1], int(1n)),
+        "contains[Text]": (x) => func("int?", op["find[byte]"](x[0], x[1])),
         "contains[Table]": (x) =>
-          op("not", func("nil?", op("at[Table]", x[0], x[1]))),
+          op.not(func("nil?", op["at[Table]"](x[0], x[1]))),
       }),
       mapOps({
         true: builtin("true"),
         false: builtin("false"),
 
         bool_to_int: (x) => conditional(x[0], int(1n), int(0n)),
-        int_to_bool: (x) => op("neq[Int]", x[0], int(0n)),
+        int_to_bool: (x) => op["neq[Int]"](x[0], int(0n)),
         int_to_hex: (x) => func("string/format", text("%X"), x[0]),
         split: (x) => func("string/split", x[1], x[0]),
 
         "char[byte]": (x) => func("string/format", text("%c"), x[0]),
         "concat[List]": (x) => func("array/concat", list([]), ...x),
         "find[byte]": (x) => func("string/find", x[1], x[0]),
-        "ord[byte]": (x) => op("ord_at[byte]", x[0], int(0n)),
+        "ord[byte]": (x) => op["ord_at[byte]"](x[0], int(0n)),
         "slice[byte]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1n)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1n)),
         "slice[List]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1n)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1n)),
       }),
       mapTo(func)({
         replace: "string/replace-all",

--- a/src/languages/javascript/index.ts
+++ b/src/languages/javascript/index.ts
@@ -131,8 +131,7 @@ const javascriptLanguage: Language = {
         argv: builtin("arguments"),
 
         "at[argv]": (x) =>
-          op(
-            "at[List]",
+          op["at[List]"](
             { ...builtin("arguments"), type: listType(textType()) },
             x[0],
           ),
@@ -147,10 +146,8 @@ const javascriptLanguage: Language = {
         true: builtin("true"),
         false: builtin("false"),
         "at[Ascii]": (x) => indexCall(x[0], x[1]),
-        "slice[List]": (x) =>
-          method(x[0], "slice", x[1], op("add", x[1], x[2])),
-        "slice[Ascii]": (x) =>
-          method(x[0], "slice", x[1], op("add", x[1], x[2])),
+        "slice[List]": (x) => method(x[0], "slice", x[1], op.add(x[1], x[2])),
+        "slice[Ascii]": (x) => method(x[0], "slice", x[1], op.add(x[1], x[2])),
         "char[Ascii]": (x) => func("String.fromCharCode", x),
         "char[byte]": (x) => func("String.fromCharCode", x),
         "sorted[Ascii]": (x) =>
@@ -178,9 +175,9 @@ const javascriptLanguage: Language = {
         right_align: (x) => method(x[0], "padStart", x[1]),
         join: (x) => method(x[0], "join", ...(isText(",")(x[1]) ? [] : [x[1]])),
         int_to_dec: (x) =>
-          op("concat[Text]", text(""), implicitConversion("int_to_dec", x[0])),
+          op["concat[Text]"](text(""), implicitConversion("int_to_dec", x[0])),
         dec_to_int: (x) =>
-          op("bit_not", op("bit_not", implicitConversion("dec_to_int", x[0]))),
+          op.bit_not(op.bit_not(implicitConversion("dec_to_int", x[0]))),
         "reversed[List]": (x) => method(x[0], "reverse"),
         "reversed[Ascii]": (x) =>
           method(
@@ -194,7 +191,7 @@ const javascriptLanguage: Language = {
             "join",
             text(""),
           ),
-        append: (x) => op("concat[List]", x[0], list([x[1]])),
+        append: (x) => op["concat[List]"](x[0], list([x[1]])),
         bool_to_int: (x) => implicitConversion("bool_to_int", x[0]),
         int_to_bool: (x) => implicitConversion("int_to_bool", x[0]),
         "contains[Table]": (x) => infix("in", x[1], x[0]),

--- a/src/languages/javascript/plugins.ts
+++ b/src/languages/javascript/plugins.ts
@@ -78,7 +78,7 @@ export function forRangeToForEachKey(node: Node) {
         ),
         tableType(textType(integerType(1, 2), true), textType()),
       ),
-      block([assignment(node.variable, op("dec_to_int", loopVar)), node.body]),
+      block([assignment(node.variable, op.dec_to_int(loopVar)), node.body]),
     );
   }
 }

--- a/src/languages/lua/index.ts
+++ b/src/languages/lua/index.ts
@@ -6,7 +6,7 @@ import {
   op,
   text,
   textType,
-  add1,
+  succ,
   isText,
   builtin,
 } from "../../IR";
@@ -92,14 +92,14 @@ const luaLanguage: Language = {
       textToIntToFirstIndexTextGetToInt,
       mapOps({
         dec_to_int: (x) =>
-          op("add", int(0n), implicitConversion("dec_to_int", x[0])),
+          op.add(int(0n), implicitConversion("dec_to_int", x[0])),
         "at[argv]": (x) =>
-          op("at[List]", { ...builtin("arg"), type: textType() }, x[0]),
+          op["at[List]"]({ ...builtin("arg"), type: textType() }, x[0]),
 
-        "ord_at[byte]": (x) => method(x[0], "byte", add1(x[1])),
-        "at[byte]": (x) => method(x[0], "sub", add1(x[1]), add1(x[1])),
+        "ord_at[byte]": (x) => method(x[0], "byte", succ(x[1])),
+        "at[byte]": (x) => method(x[0], "sub", succ(x[1]), succ(x[1])),
         "slice[byte]": (x) =>
-          method(x[0], "sub", add1(x[1]), op("add", x[1], x[2])),
+          method(x[0], "sub", succ(x[1]), op.add(x[1], x[2])),
       }),
       useIndexCalls(true),
       decomposeIntLiteral(true, true, true),
@@ -113,15 +113,15 @@ const luaLanguage: Language = {
       startsWithEndsWithToSliceEquality("byte"),
       mapOps({
         dec_to_int: (x) =>
-          op("mul", int(1n), implicitConversion("dec_to_int", x[0])),
+          op.mul(int(1n), implicitConversion("dec_to_int", x[0])),
         "at[argv]": (x) =>
-          op("at[List]", { ...builtin("arg"), type: textType() }, x[0]),
-        "ord_at[byte]": (x) => method(x[0], "byte", add1(x[1])),
+          op["at[List]"]({ ...builtin("arg"), type: textType() }, x[0]),
+        "ord_at[byte]": (x) => method(x[0], "byte", succ(x[1])),
         "ord_at_back[byte]": (x) => method(x[0], "byte", x[1]),
-        "at[byte]": (x) => method(x[0], "sub", add1(x[1]), add1(x[1])),
+        "at[byte]": (x) => method(x[0], "sub", succ(x[1]), succ(x[1])),
         "at_back[byte]": (x) => method(x[0], "sub", x[1], x[1]),
         "slice[byte]": (x) =>
-          method(x[0], "sub", add1(x[1]), op("add", x[1], x[2])),
+          method(x[0], "sub", succ(x[1]), op.add(x[1], x[2])),
       }),
       conditionalOpToAndOr(
         (n, s) => !["boolean", "void"].includes(getType(n, s).kind),
@@ -131,7 +131,7 @@ const luaLanguage: Language = {
       useIndexCalls(true),
       mapOps({
         int_to_dec: (x) =>
-          op("concat[Text]", text(""), implicitConversion("int_to_dec", x[0])),
+          op["concat[Text]"](text(""), implicitConversion("int_to_dec", x[0])),
         join: (x) => func("table.concat", isText("")(x[1]) ? [x[0]] : x),
         "size[byte]": (x) => method(x[0], "len"),
         true: builtin("true"),

--- a/src/languages/nim/index.ts
+++ b/src/languages/nim/index.ts
@@ -3,7 +3,7 @@ import {
   indexCall,
   int,
   rangeIndexCall,
-  add1,
+  succ,
   array,
   isText,
   builtin,
@@ -139,7 +139,7 @@ const nimLanguage: Language = {
       ...truncatingOpsPlugins,
       mapOps({
         argv: func("commandLineParams"),
-        "at[argv]": (x) => func("paramStr", add1(x[0])),
+        "at[argv]": (x) => func("paramStr", succ(x[0])),
       }),
       removeUnusedForVar,
       forRangeToForRangeInclusive(true),
@@ -151,13 +151,14 @@ const nimLanguage: Language = {
       useIndexCalls(),
       mapOps({
         "reversed[codepoint]": (x) =>
-          op("join", func("reversed", func("toRunes", x)), text("")),
-        "reversed[byte]": (x) => op("join", func("reversed", x[0]), text("")),
+          op.join(func("reversed", func("toRunes", x)), text("")),
+        "reversed[byte]": (x) => op.join(func("reversed", x[0]), text("")),
       }),
       mapOps({
         "char[codepoint]": (x) => prefix("$", func("Rune", x)),
-        "ord_at[byte]": (x) => func("ord", op("at[byte]", ...x)),
-        "ord_at[codepoint]": (x) => func("ord", op("at[byte]", ...x)),
+        "ord_at[byte]": (x) => func("ord", op["at[byte]"](x[0], x[1])),
+        "ord_at[codepoint]": (x) =>
+          func("ord", op["at[codepoint]"](x[0], x[1])),
         "read[line]": func("readLine", builtin("stdin")),
         join: (x) => func("join", isText("")(x[1]) ? [x[0]] : x),
         true: builtin("true"),
@@ -181,16 +182,14 @@ const nimLanguage: Language = {
               ), // Polygolf doesn't have array of tuples, so we use array of arrays instead
             ),
           ),
-        "size[codepoint]": (x) => op("size[List]", func("toRunes", x)),
+        "size[codepoint]": (x) => op["size[List]"](func("toRunes", x)),
         push: (x) =>
-          isIdent()(x[0])
-            ? assignment(x[0], op("append", x[0], x[1]))
-            : undefined,
-        int_to_bool: (x) => op("eq[Int]", x[0], int(0n)),
+          isIdent()(x[0]) ? assignment(x[0], op.append(x[0], x[1])) : undefined,
+        int_to_bool: (x) => op["eq[Int]"](x[0], int(0n)),
         int_to_bin_aligned: (x) =>
-          func("align", op("int_to_bin", x[0]), x[1], text("0")),
+          func("align", op.int_to_bin(x[0]), x[1], text("0")),
         int_to_hex_aligned: (x) =>
-          func("align", op("int_to_hex", x[0]), x[1], text("0")),
+          func("align", op.int_to_hex(x[0]), x[1], text("0")),
       }),
       mapTo(func)({
         gcd: "gcd",

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -82,7 +82,7 @@ export function useUnsignedDivision(node: Node, spine: Spine) {
   if (isOp("trunc_div", "rem")(node)) {
     return isSubtype(getType(node.args[0], spine), integerType(0)) &&
       isSubtype(getType(node.args[0], spine), integerType(0))
-      ? op(`unsigned_${node.op}`, ...node.args)
+      ? op[`unsigned_${node.op}`](...node.args)
       : undefined;
   }
 }
@@ -109,14 +109,14 @@ export function useBackwardsIndex(node: Node, spine: Spine) {
     isOp()(node) &&
     (node.op.includes("at_back") || node.op.includes("slice_back"))
   ) {
-    return op(
+    return op.unsafe(
       node.op,
       ...replaceAtIndex(
         node.args,
         1,
         prefix(
           "system.^",
-          op("neg", (node as Op<`${string}at_back${string}` & OpCode>).args[1]),
+          op.neg((node as Op<`${string}at_back${string}` & OpCode>).args[1]),
         ),
       ),
     );
@@ -125,9 +125,9 @@ export function useBackwardsIndex(node: Node, spine: Spine) {
 
 export function getEndIndex(start: Node, length: Node) {
   if (start.kind === "Prefix" && start.name === "system.^") {
-    return prefix(start.name, op("sub", start.arg, length));
+    return prefix(start.name, op.sub(start.arg, length));
   }
-  return op("add", start, length);
+  return op.add(start, length);
 }
 
 export function removeSystemNamespace(node: Node, spine: Spine) {

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -9,8 +9,8 @@ import {
   isSubtype,
   op,
   prefix,
-  Op,
-  OpCode,
+  type Op,
+  type OpCode,
 } from "../../IR";
 import { getType } from "../../common/getType";
 import type { Plugin } from "../../common/Language";

--- a/src/languages/nim/plugins.ts
+++ b/src/languages/nim/plugins.ts
@@ -9,6 +9,8 @@ import {
   isSubtype,
   op,
   prefix,
+  Op,
+  OpCode,
 } from "../../IR";
 import { getType } from "../../common/getType";
 import type { Plugin } from "../../common/Language";
@@ -107,7 +109,10 @@ export function useBackwardsIndex(node: Node, spine: Spine) {
       ...replaceAtIndex(
         node.args,
         1,
-        prefix("system.^", op("neg", node.args[1])),
+        prefix(
+          "system.^",
+          op("neg", (node as Op<`${string}at_back${string}` & OpCode>).args[1]),
+        ),
       ),
     );
   }

--- a/src/languages/polygolf/emit.ts
+++ b/src/languages/polygolf/emit.ts
@@ -117,7 +117,7 @@ function emitNodeWithoutAnnotation(
     if (op === "set_at") {
       return emitNodeWithoutAnnotation(
         assignment(
-          opNode("at[Ascii]", args[0] as Node, args[1] as Node) as any,
+          opNode["at[Ascii]"](args[0] as Node, args[1] as Node) as any,
           args[2] as Node,
         ),
         asStatement,

--- a/src/languages/python/index.ts
+++ b/src/languages/python/index.ts
@@ -9,7 +9,7 @@ import {
   listType,
   textType,
   namedArg,
-  add1,
+  succ,
   table,
   keyValue,
   type Text,
@@ -128,10 +128,9 @@ const pythonLanguage: Language = {
         argv: builtin("sys.argv[1:]"),
 
         "at[argv]": (x) =>
-          op(
-            "at[List]",
+          op["at[List]"](
             { ...builtin("sys.argv"), type: listType(textType()) },
-            add1(x[0]),
+            succ(x[0]),
           ),
       }),
 
@@ -172,25 +171,25 @@ const pythonLanguage: Language = {
         "reversed[List]": (x) =>
           rangeIndexCall(x[0], builtin(""), builtin(""), int(-1)),
         "at[codepoint]": (x) => indexCall(x[0], x[1]),
-        "at[byte]": (x) => op("char[byte]", op("ord_at[byte]", x[0], x[1])),
+        "at[byte]": (x) => op["char[byte]"](op["ord_at[byte]"](x[0], x[1])),
         "ord_at[byte]": (x) => indexCall(func("bytes", x[0], text("u8")), x[1]),
         "ord_at_back[byte]": (x) =>
           indexCall(func("bytes", x[0], text("u8")), x[1]),
         "slice[codepoint]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1)),
         "slice[byte]": (x) =>
           method(
             rangeIndexCall(
               func("bytes", x[0], text("u8")),
               x[1],
-              op("add", x[1], x[2]),
+              op.add(x[1], x[2]),
               int(1),
             ),
             "decode",
             text("u8"),
           ),
         "slice[List]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1)),
         split: (x) => method(x[0], "split", x[1]),
         split_whitespace: (x) => method(x[0], "split"),
 
@@ -225,11 +224,11 @@ const pythonLanguage: Language = {
           ),
 
         push: (x) => method(x[0], "append", x[1]),
-        append: (x) => op("concat[List]", x[0], list([x[1]])),
+        append: (x) => op["concat[List]"](x[0], list([x[1]])),
         right_align: (x) =>
           infix(
             "%",
-            op("concat[Text]", text("%"), op("int_to_dec", x[1]), text("s")),
+            op["concat[Text]"](text("%"), op.int_to_dec(x[1]), text("s")),
             x[0],
           ),
         int_to_bin: (x) => func("format", x[0], text("b")),
@@ -237,18 +236,18 @@ const pythonLanguage: Language = {
           func(
             "format",
             x[0],
-            op("concat[Text]", text("0"), op("int_to_dec", x[1]), text("b")),
+            op["concat[Text]"](text("0"), op.int_to_dec(x[1]), text("b")),
           ),
         int_to_hex: (x) => infix("%", text("%X"), x[0]),
         int_to_hex_aligned: (x) =>
           infix(
             "%",
-            op("concat[Text]", text("%0"), op("int_to_dec", x[1]), text("X")),
+            op["concat[Text]"](text("%0"), op.int_to_dec(x[1]), text("X")),
             x[0],
           ),
         int_to_bool: (x) => implicitConversion("int_to_bool", x[0]),
         bool_to_int: (x) =>
-          op("mul", int(1n), implicitConversion("bool_to_int", x[0])),
+          op.mul(int(1n), implicitConversion("bool_to_int", x[0])),
         include: (x) => method(x[0], "add", x[1]),
         starts_with: (x) => method(x[0], "startsWith", x[1]),
         ends_with: (x) => method(x[0], "endsWith", x[1]),

--- a/src/languages/swift/index.ts
+++ b/src/languages/swift/index.ts
@@ -5,7 +5,7 @@ import {
   namedArg,
   op,
   text,
-  add1,
+  succ,
   propertyCall as prop,
   isText,
   builtin,
@@ -103,10 +103,10 @@ const swiftLanguage: Language = {
       mapOps({
         argv: builtin("CommandLine.arguments[1...]"),
         "at[argv]": (x) =>
-          op("at[List]", builtin("CommandLine.arguments"), add1(x[0])),
-        "ord[codepoint]": (x) => op("ord_at[codepoint]", x[0], int(0n)),
-        "ord[byte]": (x) => op("ord_at[byte]", x[0], int(0n)),
-        "at[byte]": (x) => op("char[byte]", op("ord_at[byte]", ...x)),
+          op["at[List]"](builtin("CommandLine.arguments"), succ(x[0])),
+        "ord[codepoint]": (x) => op["ord_at[codepoint]"](x[0], int(0n)),
+        "ord[byte]": (x) => op["ord_at[byte]"](x[0], int(0n)),
+        "at[byte]": (x) => op["char[byte]"](op["ord_at[byte]"](x[0], x[1])),
       }),
 
       decomposeIntLiteral(),
@@ -122,10 +122,10 @@ const swiftLanguage: Language = {
         "read[line]": func("readLine"),
         argv: builtin("CommandLine.arguments[1...]"),
         "at[argv]": (x) =>
-          op("at[List]", builtin("CommandLine.arguments"), add1(x[0])),
-        "ord[codepoint]": (x) => op("ord_at[codepoint]", x[0], int(0n)),
-        "ord[byte]": (x) => op("ord_at[byte]", x[0], int(0n)),
-        "at[byte]": (x) => op("char[byte]", op("ord_at[byte]", ...x)),
+          op["at[List]"](builtin("CommandLine.arguments"), succ(x[0])),
+        "ord[codepoint]": (x) => op["ord_at[codepoint]"](x[0], int(0n)),
+        "ord[byte]": (x) => op["ord_at[byte]"](x[0], int(0n)),
+        "at[byte]": (x) => op["char[byte]"](op["ord_at[byte]"](x[0], x[1])),
       }),
       implicitlyConvertPrintArg,
       mapOps({
@@ -143,12 +143,12 @@ const swiftLanguage: Language = {
           isInt(0n)(x[1])
             ? method(x[0], "prefix", x[2])
             : method(
-                method(x[0], "prefix", op("add", x[1], x[2])),
+                method(x[0], "prefix", op.add(x[1], x[2])),
                 "suffix",
                 x[2],
               ),
         "slice[List]": (x) =>
-          rangeIndexCall(x[0], x[1], op("add", x[1], x[2]), int(1n)),
+          rangeIndexCall(x[0], x[1], op.add(x[1], x[2]), int(1n)),
         "ord_at[codepoint]": (x) =>
           prop(
             indexCall(func("Array", prop(x[0], "unicodeScalars")), x[1]),
@@ -173,7 +173,7 @@ const swiftLanguage: Language = {
             x[0],
             "split",
             namedArg("separator", x[1]),
-            namedArg("omittingEmptySubsequences", op("false")),
+            namedArg("omittingEmptySubsequences", op.false),
           ),
         repeat: (x) =>
           func("String", namedArg("repeating", x[0]), namedArg("count", x[1])),
@@ -184,17 +184,16 @@ const swiftLanguage: Language = {
         "find[List]": (x) => method(x[0], "index", namedArg("of", x[1])),
         "find[codepoint]": (x) =>
           conditional(
-            op("contains[Text]", x[0], x[1]),
-            op(
-              "size[codepoint]",
-              op("at[List]", op("split", x[0], x[1]), int(0n)),
+            op["contains[Text]"](x[0], x[1]),
+            op["size[codepoint]"](
+              op["at[List]"](op.split(x[0], x[1]), int(0n)),
             ),
             int(-1n),
           ),
         "find[byte]": (x) =>
           conditional(
-            op("contains[Text]", x[0], x[1]),
-            op("size[byte]", op("at[List]", op("split", x[0], x[1]), int(0n))),
+            op["contains[Text]"](x[0], x[1]),
+            op["size[byte]"](op["at[List]"](op.split(x[0], x[1]), int(0n))),
             int(-1n),
           ),
         pow: (x) =>
@@ -203,7 +202,7 @@ const swiftLanguage: Language = {
         "print[Text]": (x) =>
           func("print", x, namedArg("terminator", text(""))),
         dec_to_int: (x) => postfix("!", func("Int", x)),
-        append: (x) => op("concat[List]", x[0], list([x[1]])),
+        append: (x) => op["concat[List]"](x[0], list([x[1]])),
         include: (x) => method(x[0], "insert", x[1]),
         push: (x) => method(x[0], "append", x[1]),
 
@@ -213,13 +212,13 @@ const swiftLanguage: Language = {
         true: builtin("true"),
         false: builtin("false"),
         bool_to_int: (x) => conditional(x[0], int(1n), int(0n)),
-        int_to_bool: (x) => op("neq[Int]", x[0], int(0n)),
+        int_to_bool: (x) => op["neq[Int]"](x[0], int(0n)),
         int_to_hex: (x) =>
           func(
             "String",
             x[0],
             namedArg("radix", int(16n)),
-            namedArg("uppercase", op("true")),
+            namedArg("uppercase", op.true),
           ),
         int_to_bin: (x) => func("String", x[0], namedArg("radix", int(2n))),
         int_to_hex_aligned: (x) =>
@@ -227,23 +226,19 @@ const swiftLanguage: Language = {
             "String",
             namedArg(
               "format",
-              op("concat[Text]", text("%0"), op("int_to_dec", x[1]), text("X")),
+              op["concat[Text]"](text("%0"), op.int_to_dec(x[1]), text("X")),
             ),
             x[0],
           ),
         int_to_bin_aligned: (x) =>
           method(
-            op(
-              "concat[Text]",
-              op("repeat", text("0"), x[1]),
-              op("int_to_bin", x[0]),
-            ),
+            op["concat[Text]"](op.repeat(text("0"), x[1]), op.int_to_bin(x[0])),
             "suffix",
             x[1],
           ),
         right_align: (x) =>
           method(
-            op("concat[Text]", op("repeat", text(" "), x[1]), x[0]),
+            op["concat[Text]"](op.repeat(text(" "), x[1]), x[0]),
             "suffix",
             x[1],
           ),

--- a/src/plugins/arithmetic.ts
+++ b/src/plugins/arithmetic.ts
@@ -294,7 +294,7 @@ export function mulOrDivToBitShift(fromMul = true, fromDiv = true): Plugin {
         }
         const powNode = node.args.find(
           (x) => isOp("pow")(x) && isInt(2n)(x.args[0]),
-        ) as Op | undefined;
+        ) as Op<"pow"> | undefined;
         if (powNode !== undefined) {
           return op(
             "bit_shift_left",

--- a/src/plugins/conditions.ts
+++ b/src/plugins/conditions.ts
@@ -20,23 +20,20 @@ export function safeConditionalOpToAt(
       if (node.kind === "ConditionalOp" && node.isSafe) {
         switch (type) {
           case "Array":
-            return op(
-              "at[Array]",
+            return op["at[Array]"](
               array([node.alternate, node.consequent]),
-              op("bool_to_int", node.condition),
+              op.bool_to_int(node.condition),
             );
           case "List":
-            return op(
-              "at[List]",
+            return op["at[List]"](
               list([node.alternate, node.consequent]),
-              op("bool_to_int", node.condition),
+              op.bool_to_int(node.condition),
             );
           case "Table":
-            return op(
-              "at[Table]",
+            return op["at[Table]"](
               table([
-                keyValue(op("true"), node.consequent),
-                keyValue(op("false"), node.alternate),
+                keyValue(op.true, node.consequent),
+                keyValue(op.false, node.alternate),
               ]),
               node.condition,
             );
@@ -62,19 +59,16 @@ export function conditionalOpToAndOr(
             context,
           )
         )
-          return op(
-            "unsafe_or",
-            op("unsafe_and", node.condition, node.consequent),
+          return op.unsafe_or(
+            op.unsafe_and(node.condition, node.consequent),
             node.alternate,
           );
         if (falseyFallback !== undefined) {
           const opCode = `at[${falseyFallback}]` as const;
           const collection = falseyFallback === "List" ? list : array;
-          return op(
-            opCode,
-            op(
-              "unsafe_or",
-              op("unsafe_and", node.condition, collection([node.consequent])),
+          return op[opCode](
+            op.unsafe_or(
+              op.unsafe_and(node.condition, collection([node.consequent])),
               collection([node.alternate]),
             ),
             int(0n),
@@ -90,7 +84,7 @@ export const flipConditionalOp: Plugin = {
   visit(node) {
     if (node.kind === "ConditionalOp" && node.isSafe) {
       return conditional(
-        op("not", node.condition),
+        op.not(node.condition),
         node.alternate,
         node.consequent,
         true,
@@ -104,7 +98,7 @@ export const flipIfStatement: Plugin = {
   visit(node) {
     if (node.kind === "If" && node.alternate !== undefined) {
       return ifStatement(
-        op("not", node.condition),
+        op.not(node.condition),
         node.alternate,
         node.consequent,
       );

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -161,7 +161,7 @@ export function forRangeToForEach(...ops: GetOp[]): Plugin {
         isInt(0n)(node.start) &&
         ((isOp()(node.end) &&
           ops.includes(lengthOpToGetOp.get(node.end.op) as any) &&
-          isIdent()(node.end.args[0])) ||
+          isIdent()(node.end.args[0]!)) ||
           isInt()(node.end))
       ) {
         const indexVar = node.variable;
@@ -188,7 +188,7 @@ export function forRangeToForEach(...ops: GetOp[]): Plugin {
             if (
               isOp()(n) &&
               n.args[0] === indexedCollection &&
-              isUserIdent(indexVar.name)(n.args[1])
+              isUserIdent(indexVar.name)(n.args[1]!)
             )
               return elementIdentifier;
           }).node;

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -24,8 +24,8 @@ import {
   isOp,
   isSubtype,
   integerType,
-  add1,
-  sub1,
+  succ,
+  prec,
   isText,
   isIdent,
   isUserIdent,
@@ -45,7 +45,7 @@ export function forRangeToForRangeInclusive(skip1Step = false): Plugin {
         return forRange(
           node.variable,
           node.start,
-          sub1(node.end),
+          prec(node.end),
           node.increment,
           node.body,
           true,
@@ -63,12 +63,12 @@ export function forRangeToWhile(node: Node, spine: Spine) {
     }
     const increment = assignment(
       node.variable,
-      op("add", node.variable, node.increment),
+      op.add(node.variable, node.increment),
     );
     return block([
       assignment(node.variable, node.start),
       whileLoop(
-        op(node.inclusive ? "leq" : "lt", node.variable, node.end),
+        op[node.inclusive ? "leq" : "lt"](node.variable, node.end),
         block([node.body, increment]),
       ),
     ]);
@@ -85,8 +85,8 @@ export function forRangeToForCLike(node: Node, spine: Spine) {
     const variable = node.variable ?? id();
     return forCLike(
       assignment(variable, node.start),
-      op(node.inclusive ? "leq" : "lt", variable, node.end),
-      assignment(variable, op("add", variable, node.increment)),
+      op[node.inclusive ? "leq" : "lt"](variable, node.end),
+      assignment(variable, op.add(variable, node.increment)),
       node.body,
     );
   }
@@ -253,7 +253,7 @@ function literalLength(expr: Text | List, countTextBytes: boolean): number {
 
 export function forArgvToForEach(node: Node) {
   if (node.kind === "ForArgv") {
-    return forEach(node.variable, op("argv"), node.body);
+    return forEach(node.variable, op.argv, node.body);
   }
 }
 
@@ -264,7 +264,7 @@ export function forArgvToForRange(overshoot = true, inclusive = false): Plugin {
       if (node.kind === "ForArgv") {
         const indexVar = id(node.variable.name + "+index");
         const newBody = block([
-          assignment(node.variable, op("at[argv]", indexVar)),
+          assignment(node.variable, op["at[argv]"](indexVar)),
           node.body,
         ]);
         return forRange(
@@ -272,9 +272,9 @@ export function forArgvToForRange(overshoot = true, inclusive = false): Plugin {
           int(0),
           overshoot
             ? inclusive
-              ? sub1(int(node.argcUpperBound))
+              ? prec(int(node.argcUpperBound))
               : int(node.argcUpperBound)
-            : op("argc"),
+            : op.argc,
           int(1),
           newBody,
           inclusive,
@@ -330,13 +330,13 @@ export function shiftRangeOneUp(node: Node, spine: Spine) {
     const newVar = id(node.variable.name + "+shift");
     const newBodySpine = bodySpine.withReplacer((x) =>
       newVar !== undefined && isIdent(node.variable!)(x)
-        ? sub1(newVar)
+        ? prec(newVar)
         : undefined,
     );
     return forRange(
       newVar,
-      add1(node.start),
-      add1(node.end),
+      succ(node.start),
+      succ(node.end),
       int(1n),
       newBodySpine.node,
       node.inclusive,
@@ -361,7 +361,7 @@ export function forRangeToForDifferenceRange(
         return forDifferenceRange(
           node.variable,
           node.start,
-          op("sub", node.end, node.start),
+          op.sub(node.end, node.start),
           node.increment,
           node.body,
           node.inclusive,
@@ -382,15 +382,13 @@ export function forRangeToForRangeOneStep(node: Node, spine: Spine) {
       newVar,
       int(0n),
       node.inclusive
-        ? op("div", op("sub", node.end, node.start), node.increment)
-        : add1(
-            op("div", op("sub", sub1(node.end), node.start), node.increment),
-          ),
+        ? op.div(op.sub(node.end, node.start), node.increment)
+        : succ(op.div(op.sub(prec(node.end), node.start), node.increment)),
       int(1n),
       block([
         assignment(
           node.variable,
-          op("add", op("mul", newVar, node.increment), node.start),
+          op.add(op.mul(newVar, node.increment), node.start),
         ),
         node.body,
       ]),

--- a/src/plugins/ops.ts
+++ b/src/plugins/ops.ts
@@ -200,10 +200,17 @@ export function useIndexCalls(
         } else {
           indexNode = indexCall(node.args[0], node.args[1]);
         }
-        if (!node.op.startsWith("set_")) {
-          return indexNode;
-        } else {
+        if (
+          isOp(
+            "set_at[Array]",
+            "set_at[List]",
+            "set_at_back[List]",
+            "set_at[Table]",
+          )(node)
+        ) {
           return assignment(indexNode, node.args[2]);
+        } else {
+          return indexNode;
         }
       }
     },

--- a/src/plugins/packing.ts
+++ b/src/plugins/packing.ts
@@ -28,19 +28,14 @@ export function useDecimalConstantPackedPrinter(node: Node, spine: Spine) {
         ["packindex", 0, packed.length],
         assignment(
           "result",
-          op(
-            "concat[Text]",
+          op["concat[Text]"](
             id("result"),
-            op(
-              "slice[byte]",
-              op(
-                "int_to_dec",
-                op(
-                  "add",
+            op["slice[byte]"](
+              op.int_to_dec(
+                op.add(
                   int(72n),
-                  op(
-                    "ord[byte]",
-                    op("at[byte]", text(packed), id("packindex")),
+                  op["ord[byte]"](
+                    op["at[byte]"](text(packed), id("packindex")),
                   ),
                 ),
               ),
@@ -72,7 +67,7 @@ export function useLowDecimalListPackedPrinter(node: Node) {
     if (packed === null) return;
     return forRangeCommon(
       ["packindex", 0, packed.length],
-      print(op("ord_at[byte]", text(packed), id("packindex"))),
+      print(op["ord_at[byte]"](text(packed), id("packindex"))),
     );
   }
 }

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -169,7 +169,7 @@ export function splitPrint(node: Node, spine: Spine) {
                 ? block([])
                 : op("print[Text]", x.expr)
               : assignments.includes(x as any)
-              ? op("print[Text]", ((x as Assignment).expr as Op).args[1])
+              ? op("print[Text]", ((x as Assignment).expr as Op).args[1]!)
               : undefined,
           ).node;
         }

--- a/src/plugins/print.ts
+++ b/src/plugins/print.ts
@@ -25,7 +25,7 @@ import { getWrites } from "../common/symbols";
 export const printLnToPrint = mapOps(
   {
     "println[Text]": (x) =>
-      op("print[Text]", op("concat[Text]", x[0], text("\n"))),
+      op["print[Text]"](op["concat[Text]"](x[0], text("\n"))),
   },
   "printLnToPrint",
 );
@@ -51,7 +51,7 @@ export function golfLastPrint(toPrintln = true): Plugin {
         }
         if (arg !== lastStatement.args[0] || lastStatement.op !== newOp) {
           return blockOrSingle(
-            replaceAtIndex(statements, statements.length - 1, op(newOp, arg)),
+            replaceAtIndex(statements, statements.length - 1, op[newOp](arg)),
           );
         }
       }
@@ -76,7 +76,7 @@ export function golfLastPrintInt(toPrintlnInt = true): Plugin {
           replaceAtIndex(
             statements,
             statements.length - 1,
-            op(newOp, lastStatement.args[0]),
+            op[newOp](lastStatement.args[0]),
           ),
         );
       }
@@ -103,15 +103,15 @@ export const printToImplicitOutput = mapOps(
 
 export function printConcatToMultiPrint(node: Node, spine: Spine) {
   if (isOp("print[Text]")(node) && isOp("concat[Text]")(node.args[0])) {
-    return block(node.args[0].args.map((x) => op("print[Text]", x)));
+    return block(node.args[0].args.map(op["print[Text]"]));
   }
 }
 
 export const putcToPrintChar = mapOps(
   {
-    "putc[Ascii]": (x) => op("print[Text]", op("char[Ascii]", x[0])),
-    "putc[byte]": (x) => op("print[Text]", op("char[byte]", x[0])),
-    "putc[codepoint]": (x) => op("print[Text]", op("char[codepoint]", x[0])),
+    "putc[Ascii]": (x) => op["print[Text]"](op["char[Ascii]"](x[0])),
+    "putc[byte]": (x) => op["print[Text]"](op["char[byte]"](x[0])),
+    "putc[codepoint]": (x) => op["print[Text]"](op["char[codepoint]"](x[0])),
   },
   "putcToPrintChar",
 );
@@ -128,8 +128,7 @@ export function mergePrint(
       isOp("print[Text]", "println[Text]")(node)
         ? assignment(
             variable,
-            op(
-              "concat[Text]",
+            op["concat[Text]"](
               variable,
               node.args[0],
               ...(node.op === "print[Text]" ? [] : [text("\n")]),
@@ -140,7 +139,7 @@ export function mergePrint(
     return block([
       assignment(variable, text("")),
       newSpine.node,
-      op("print[Text]", variable),
+      op["print[Text]"](variable),
     ]);
   }
 }
@@ -167,9 +166,9 @@ export function splitPrint(node: Node, spine: Spine) {
               : x === assignments[0]
               ? isText("")(x.expr)
                 ? block([])
-                : op("print[Text]", x.expr)
+                : op["print[Text]"](x.expr)
               : assignments.includes(x as any)
-              ? op("print[Text]", ((x as Assignment).expr as Op).args[1]!)
+              ? op["print[Text]"](((x as Assignment).expr as Op).args[1]!)
               : undefined,
           ).node;
         }

--- a/src/plugins/static.ts
+++ b/src/plugins/static.ts
@@ -11,8 +11,8 @@ export function golfStringListLiteral(useTextSplitWhitespace = true): Plugin {
         const strings = node.exprs.map((x) => x.value);
         const delim = getDelim(strings, useTextSplitWhitespace);
         return delim === true
-          ? op("split_whitespace", text(strings.join(" ")))
-          : op("split", text(strings.join(delim)), text(delim));
+          ? op.split_whitespace(text(strings.join(" ")))
+          : op.split(text(strings.join(delim)), text(delim));
       }
     },
   };
@@ -57,14 +57,14 @@ export function listOpsToTextOps(
           const joined = text(texts.join(""));
           if (texts.every((x) => byteLength(x) === 1)) {
             if (node.op === "at[List]" && ops.includes("at[byte]"))
-              return op("at[byte]", joined, node.args[1]);
+              return op["at[byte]"](joined, node.args[1]);
             if (node.op === "find[List]" && ops.includes("find[byte]"))
-              return op("find[byte]", joined, node.args[1]);
+              return op["find[byte]"](joined, node.args[1]);
           }
           if (node.op === "at[List]" && ops.includes("at[codepoint]"))
-            return op("at[codepoint]", joined, node.args[1]);
+            return op["at[codepoint]"](joined, node.args[1]);
           if (node.op === "find[List]" && ops.includes("find[codepoint]"))
-            return op("find[codepoint]", joined, node.args[1]);
+            return op["find[codepoint]"](joined, node.args[1]);
         }
       }
     },
@@ -79,7 +79,7 @@ export function hardcode(): Plugin {
       if (!isOp("print[Text]")(node) || !isText()(node.args[0])) {
         try {
           const output = getOutput(node);
-          if (output !== "") return op("print[Text]", text(output));
+          if (output !== "") return op["print[Text]"](text(output));
         } catch {}
       }
     },

--- a/src/plugins/tables.ts
+++ b/src/plugins/tables.ts
@@ -58,18 +58,16 @@ export function tableHashing(
           let lastUsed = array.length - 1;
           while (array[lastUsed] === null) lastUsed--;
 
-          return op(
-            "at[List]",
+          return op["at[List]"](
             list(
               array
                 .slice(0, lastUsed + 1)
                 .map((x) => x ?? defaultValue(tableType.value)),
             ),
-            op(
-              "mod",
+            op.mod(
               mod === array.length
                 ? hash(getKey)
-                : op("mod", hash(getKey), int(mod)),
+                : op.mod(hash(getKey), int(mod)),
               int(array.length),
             ),
           );
@@ -136,7 +134,7 @@ export function tableToListLookup(node: Node) {
     ) {
       const values = node.args[0].kvPairs.map((x) => x.value);
       const at = node.args[1];
-      return op("at[List]", list(values), op("find[List]", list(keys), at));
+      return op["at[List]"](list(values), op["find[List]"](list(keys), at));
     }
   }
 }

--- a/src/plugins/textOps.ts
+++ b/src/plugins/textOps.ts
@@ -11,7 +11,7 @@ export function usePrimaryTextOps(char: "byte" | "codepoint"): Plugin {
       if (!isOp()(node) || !node.op.includes("[Ascii]")) return;
       const replacement = node.op.replace("[Ascii]", `[${char}]`);
       if (isOpCode(replacement)) {
-        return op(replacement, ...node.args);
+        return op.unsafe(replacement, ...node.args);
       }
     },
   };
@@ -19,13 +19,16 @@ export function usePrimaryTextOps(char: "byte" | "codepoint"): Plugin {
 
 export const textGetToIntToTextGet: Plugin = mapOps(
   {
-    "ord_at[Ascii]": (x) => op("ord[Ascii]", op("at[Ascii]", ...x)),
-    "ord_at[byte]": (x) => op("ord[byte]", op("at[byte]", ...x)),
-    "ord_at[codepoint]": (x) => op("ord[codepoint]", op("at[codepoint]", ...x)),
-    "ord_at_back[Ascii]": (x) => op("ord[Ascii]", op("at_back[Ascii]", ...x)),
-    "ord_at_back[byte]": (x) => op("ord[byte]", op("at_back[byte]", ...x)),
+    "ord_at[Ascii]": (x) => op["ord[Ascii]"](op["at[Ascii]"](x[0], x[1])),
+    "ord_at[byte]": (x) => op["ord[byte]"](op["at[byte]"](x[0], x[1])),
+    "ord_at[codepoint]": (x) =>
+      op["ord[codepoint]"](op["at[codepoint]"](x[0], x[1])),
+    "ord_at_back[Ascii]": (x) =>
+      op["ord[Ascii]"](op["at_back[Ascii]"](x[0], x[1])),
+    "ord_at_back[byte]": (x) =>
+      op["ord[byte]"](op["at_back[byte]"](x[0], x[1])),
     "ord_at_back[codepoint]": (x) =>
-      op("ord[codepoint]", op("at_back[codepoint]", ...x)),
+      op["ord[codepoint]"](op["at_back[codepoint]"](x[0], x[1])),
   },
   "textGetToIntToTextGet",
 );
@@ -33,10 +36,10 @@ export const textGetToIntToTextGet: Plugin = mapOps(
 export const textToIntToTextGetToInt: Plugin = mapOps(
   {
     "ord[byte]": (x) =>
-      isOp("at[byte]")(x[0]) ? op("ord_at[byte]", ...x[0].args) : undefined,
+      isOp("at[byte]")(x[0]) ? op["ord_at[byte]"](...x[0].args) : undefined,
     "ord[codepoint]": (x) =>
       isOp("at[codepoint]")(x[0])
-        ? op("ord_at[codepoint]", ...x[0].args)
+        ? op["ord_at[codepoint]"](...x[0].args)
         : undefined,
   },
   "textToIntToTextGetToInt",
@@ -44,18 +47,18 @@ export const textToIntToTextGetToInt: Plugin = mapOps(
 
 export const textGetToTextGetToIntToText: Plugin = mapOps(
   {
-    "at[byte]": (x) => op("char[byte]", op("ord_at[byte]", ...x)),
+    "at[byte]": (x) => op["char[byte]"](op["ord_at[byte]"](x[0], x[1])),
     "at[codepoint]": (x) =>
-      op("char[codepoint]", op("ord_at[codepoint]", ...x)),
+      op["char[codepoint]"](op["ord_at[codepoint]"](x[0], x[1])),
   },
   "textGetToTextGetToIntToText",
 );
 
 export const textToIntToFirstIndexTextGetToInt: Plugin = mapOps(
   {
-    "ord[Ascii]": (x) => op("ord_at[Ascii]", x[0], int(0n)),
-    "ord[byte]": (x) => op("ord_at[byte]", x[0], int(0n)),
-    "ord[codepoint]": (x) => op("ord_at[codepoint]", x[0], int(0n)),
+    "ord[Ascii]": (x) => op["ord_at[Ascii]"](x[0], int(0n)),
+    "ord[byte]": (x) => op["ord_at[byte]"](x[0], int(0n)),
+    "ord[codepoint]": (x) => op["ord_at[codepoint]"](x[0], int(0n)),
   },
   "textToIntToFirstIndexTextGetToInt",
 );
@@ -93,7 +96,7 @@ export function useMultireplace(singleCharInputsOnly = false): Plugin {
             ![...bInSet].some((x) => aOutSet.has(x)) &&
             ![...aInSet].some((x) => bOutSet.has(x))
           ) {
-            return op("text_multireplace", ...node.args[0].args, ...b);
+            return op.unsafe("text_multireplace", ...node.args[0].args, ...b);
           }
         }
       }
@@ -103,7 +106,7 @@ export function useMultireplace(singleCharInputsOnly = false): Plugin {
 
 export const replaceToSplitAndJoin: Plugin = mapOps(
   {
-    replace: ([x, y, z]) => op("join", op("split", x, y), z),
+    replace: ([x, y, z]) => op.join(op.split(x, y), z),
   },
   "replaceToSplitAndJoin",
 );
@@ -115,25 +118,21 @@ export function startsWithEndsWithToSliceEquality(
     name: `startsWithEndsWithToSliceEquality(${JSON.stringify(char)})`,
     visit(node) {
       if (isOp("starts_with")(node)) {
-        return op(
-          "eq[Text]",
-          op(
-            `slice[${char}]`,
+        return op["eq[Text]"](
+          op[`slice[${char}]`](
             node.args[0],
             int(0),
-            op(`size[${char}]`, node.args[1]),
+            op[`size[${char}]`](node.args[1]),
           ),
           node.args[1],
         );
       }
       if (isOp("ends_with")(node)) {
-        return op(
-          "eq[Text]",
-          op(
-            `slice_back[${char}]`,
+        return op["eq[Text]"](
+          op[`slice_back[${char}]`](
             node.args[0],
-            op("neg", op(`size[${char}]`, node.args[1])),
-            op(`size[${char}]`, node.args[1]),
+            op.neg(op[`size[${char}]`](node.args[1])),
+            op[`size[${char}]`](node.args[1]),
           ),
           node.args[1],
         );


### PR DESCRIPTION
Provides constructor functions corresponding to each opcode, so that arities can be statically checked by ts. Former `op("add", a, b)` is now written as `op.add(a, b)`. The old arity unaware function `op` is now accessible as `op.unsafe`.