### PR TITLE
Janet: always use `var` instead of `def`

### DIFF
--- a/src/languages/janet/emit.ts
+++ b/src/languages/janet/emit.ts
@@ -85,10 +85,7 @@ export default function emitProgram(program: IR.Node): TokenTree {
             `Declaration cannot contain ${assignment.kind}`,
           );
         }
-        const assignKeyword =
-          assignment.expr.kind === "Identifier" && assignment.expr.builtin
-            ? "def"
-            : "var";
+        const assignKeyword = "var";
         return [
           "(",
           assignKeyword,

--- a/src/programs/ops.test.md
+++ b/src/programs/ops.test.md
@@ -42,7 +42,7 @@ or $x $y $z;
 ```
 
 ```janet nogolf
-(var a 0)(var b 0)(var c 0)(def x true)(def y true)(def z true)(min a b c)(* a b c)(or x y z)
+(var a 0)(var b 0)(var c 0)(var x true)(var y true)(var z true)(min a b c)(* a b c)(or x y z)
 ```
 
 ```js nogolf


### PR DESCRIPTION
This fixes #341 by always using `var`.

The [documentation](https://janet-lang.org/docs/specials.html) says that `def` and `var` are identical, except for allowing mutation for variables declared with `var`, and as both have the same length, there is no benefit to `def` when golfing.