### PR TITLE
Add md test lint

### DIFF
--- a/src/markdown-tests/build.ts
+++ b/src/markdown-tests/build.ts
@@ -108,7 +108,7 @@ function parseSuite(markdown: string): Describe {
           );
           if (!expectedVisibleTitle.test(test.visibleTitle)) {
             throw new Error(
-              `Expected ${expectedVisibleTitle} above the lang test fence block, but got '${test.visibleTitle}' (${test.language}).`,
+              `Expected ${expectedVisibleTitle} above the lang test fence block, but got '${test.visibleTitle}'.`,
             );
           }
         }

--- a/src/programs/code.golf-default.test.md
+++ b/src/programs/code.golf-default.test.md
@@ -63,6 +63,8 @@ for i in range(10):p(i)
 for a in sys.argv[1:]:p(a)
 ```
 
+_Swift_
+
 ```swift
 print("Hello, World!")
 for i in 0...9{print(i)}

--- a/src/programs/code.golf-default.test.md
+++ b/src/programs/code.golf-default.test.md
@@ -26,6 +26,15 @@ _Golfscript_
 "10,{:i;i n}%a{:b;b n}%
 ```
 
+_Javascript_
+
+```javascript
+p=print
+p`Hello, World!`
+for(i in''+1e9)p(i)
+for(a of arguments)p(a)
+```
+
 _Lua_
 
 ```lua
@@ -54,19 +63,8 @@ for i in range(10):p(i)
 for a in sys.argv[1:]:p(a)
 ```
 
-_Swift_
-
 ```swift
 print("Hello, World!")
 for i in 0...9{print(i)}
 for a in CommandLine.arguments[1...]{print(a)}
-```
-
-_Javascript_
-
-```javascript
-p=print
-p`Hello, World!`
-for(i in''+1e9)p(i)
-for(a of arguments)p(a)
 ```

--- a/src/programs/ops.test.md
+++ b/src/programs/ops.test.md
@@ -14,9 +14,13 @@ $d <- 0;
 + $a (-$b) (-$c) (-$d);
 ```
 
+_Janet_
+
 ```janet nogolf
 (var a 0)(var b 0)(var c 0)(var d 0)(- a)(- a b)(-(+ a b)c d)(-(+ a b c d))(- a b c d)
 ```
+
+_Python_
 
 ```py nogolf
 a=b=c=d=0
@@ -41,9 +45,13 @@ min $a $b $c;
 or $x $y $z;
 ```
 
+_Janet_
+
 ```janet nogolf
 (var a 0)(var b 0)(var c 0)(var x true)(var y true)(var z true)(min a b c)(* a b c)(or x y z)
 ```
+
+_Javascript_
 
 ```js nogolf
 a=0
@@ -57,6 +65,8 @@ a*b*c
 x||y||z
 ```
 
+_Lua_
+
 ```lua nogolf
 a=0
 b=0
@@ -69,6 +79,8 @@ a*b*c
 x or y or z
 ```
 
+_Nim_
+
 ```nim nogolf
 var
  a,b,c=0
@@ -78,6 +90,8 @@ a*b*c
 x or y or z
 ```
 
+_Python_
+
 ```py nogolf
 a=b=c=0
 x=y=z=1
@@ -85,6 +99,8 @@ min(a,b,c)
 a*b*c
 x or y or z
 ```
+
+_Swift_
 
 ```swift nogolf
 var a=0,b=0,c=0,x=true,y=true,z=true
@@ -100,15 +116,21 @@ $c:0..9 <- 0;
 gcd $a $b $c;
 ```
 
+_Janet_
+
 ```janet nogolf
 (var a 0)(var b 0)(var c 0)(math/gcd(math/gcd a b)c)
 ```
+
+_Nim_
 
 ```nim nogolf
 import math
 var a,b,c=0
 gcd(gcd(a,b),c)
 ```
+
+_Python_
 
 ```py nogolf
 import math
@@ -123,33 +145,47 @@ $t <- (list 1 2 3);
 $t @<- 2 1;
 ```
 
+_Golfscript_
+
 ```gs nogolf
 [1 2 3]:t;t.2.@<[1]+@@)>+:t;
 ```
 
+_Janet_
+
 ```janet nogolf
 (var t @[1 2 3])(put t 2 1)
 ```
+
+_Javascript_
 
 ```js nogolf
 t=[1,2,3]
 t[2]=1
 ```
 
+_Lua_
+
 ```lua nogolf
 t={1,2,3}
 t[3]=1
 ```
+
+_Nim_
 
 ```nim nogolf
 var t= @[1,2,3]
 t[2]=1
 ```
 
+_Python_
+
 ```py nogolf
 t=[1,2,3]
 t[2]=1
 ```
+
+_Swift_
 
 ```swift nogolf
 var t=[1,2,3]
@@ -162,18 +198,26 @@ t[2]=1
 bit_count 67;
 ```
 
+_Javascript_
+
 ```js nogolf
 67.toString(2).replace(/0/g,``).length
 ```
+
+_Nim_
 
 ```nim nogolf
 include math
 popcount(67)
 ```
 
+_Python_
+
 ```py nogolf
 67.bit_count()
 ```
+
+_Swift_
 
 ```swift nogolf
 String(67,radix:2).filter({$0>"0"}).count


### PR DESCRIPTION
When there are multiple language outputs for a single input in a markdown test suite, require the languages to be in alphabetical order and require the language name to be placed above the code fence, so that it can be more easily followed when viewed [rendered to Html, like this](https://github.com/polygolf-lang/polygolf/blob/main/src/programs/code.golf-default.test.md).