### PR TITLE
Errors

### DIFF
--- a/src/IR/assignments.ts
+++ b/src/IR/assignments.ts
@@ -140,7 +140,7 @@ export function varDeclarationWithAssignment<T extends SomeAssignment>(
   ) {
     throw new UserError(
       "VarDeclarationWithAssignment needs assignments to variables.",
-      assignment.,
+      assignment,
     );
   }
   return {

--- a/src/IR/assignments.ts
+++ b/src/IR/assignments.ts
@@ -1,4 +1,4 @@
-import { PolygolfError } from "../common/errors";
+import { UserError } from "../common/errors";
 import {
   type BaseNode,
   id,
@@ -138,9 +138,9 @@ export function varDeclarationWithAssignment<T extends SomeAssignment>(
     (!isAssignment(assignment) &&
       assignment.variables.some((y) => !isIdent()(y)))
   ) {
-    throw new PolygolfError(
+    throw new UserError(
       "VarDeclarationWithAssignment needs assignments to variables.",
-      assignment.source,
+      assignment.,
     );
   }
   return {

--- a/src/IR/collections.ts
+++ b/src/IR/collections.ts
@@ -1,4 +1,4 @@
-import { InvariantError } from "@/common/errors";
+import { InvariantError } from "../common/errors";
 import {
   type BaseNode,
   type Node,

--- a/src/IR/collections.ts
+++ b/src/IR/collections.ts
@@ -1,3 +1,4 @@
+import { InvariantError } from "@/common/errors";
 import {
   type BaseNode,
   type Node,
@@ -62,7 +63,7 @@ export function isEqualToLiteral(x: Node, literal: Literal): boolean {
       isEqualToLiteral(x.value, literal.value)
     );
   }
-  throw new Error("Unknown literal kind.");
+  throw new InvariantError(`Unknown literal kind. ${literal.kind}`);
 }
 
 export function array(value: readonly Node[]): Array {

--- a/src/IR/types.ts
+++ b/src/IR/types.ts
@@ -1,4 +1,4 @@
-import { InvariantError, UserError } from "@/common/errors";
+import { InvariantError, UserError } from "../common/errors";
 import { getType } from "../common/getType";
 import { type Spine } from "../common/Spine";
 import {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,11 @@ import yargs from "yargs";
 import fs from "fs";
 import path from "path";
 import compile, { debugEmit } from "./common/compile";
-import { NotImplementedError, UserError } from "./common/errors";
+import {
+  InvariantError,
+  NotImplementedError,
+  UserError,
+} from "./common/errors";
 import languages, { findLang } from "./languages/languages";
 
 const languageChoices = [
@@ -130,6 +134,8 @@ if (options.all === true && options.output !== undefined) {
             "^",
         );
       }
+    } else if (e instanceof InvariantError) {
+      console.log(e);
     } else {
       throw e;
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,9 +4,8 @@ import yargs from "yargs";
 import fs from "fs";
 import path from "path";
 import compile, { debugEmit } from "./common/compile";
-import { PolygolfError } from "./common/errors";
+import { NotImplementedError, UserError } from "./common/errors";
 import languages, { findLang } from "./languages/languages";
-import { EmitError } from "./common/emit";
 
 const languageChoices = [
   ...new Set(languages.flatMap((x) => [x.name.toLowerCase(), x.extension])),
@@ -49,85 +48,90 @@ const options = yargs()
   .parseSync(process.argv.slice(2));
 
 if (options.all === true && options.output !== undefined) {
-  throw new Error(
+  console.log(
     "All variants options is only allowed when the output file is not specified.",
   );
-}
-
-const langs =
-  options.lang === undefined ? languages : [findLang(options.lang)!];
-let input = options.input;
-if (!fs.existsSync(input)) input += ".polygolf";
-const code = fs.readFileSync(input, { encoding: "utf-8" });
-const printingMultipleLangs = langs.length > 1 && options.output === undefined;
-for (const result of compile(
-  code,
-  {
-    objective: options.chars === true ? "chars" : "bytes",
-    getAllVariants: options.all === true,
-  },
-  ...langs,
-)) {
-  if (printingMultipleLangs) console.log(result.language);
-  if (typeof result.result === "string") {
-    if (options.output !== undefined) {
-      fs.mkdirSync(path.dirname(options.output), { recursive: true });
-      fs.writeFileSync(
-        options.output +
-          (langs.length > 1 || !options.output.includes(".")
-            ? "." + findLang(result.language)!.extension
-            : ""),
-        result.result,
-      );
-    } else {
-      console.log(result.result);
-    }
-    if (result.warnings.length > 0) {
-      console.log("Warnings:");
-      console.log(result.warnings.map((x) => x.message).join("\n"));
-    }
-    if (options.debug === true) {
-      console.log("History:");
-      console.log(result.history.map(([c, name]) => `${c} ${name}`).join("\n"));
-
-      if (result.errors.length > 0) {
-        console.log("Errors:");
+} else {
+  const langs =
+    options.lang === undefined ? languages : [findLang(options.lang)!];
+  let input = options.input;
+  if (!fs.existsSync(input)) input += ".polygolf";
+  const code = fs.readFileSync(input, { encoding: "utf-8" });
+  const printingMultipleLangs =
+    langs.length > 1 && options.output === undefined;
+  for (const result of compile(
+    code,
+    {
+      objective: options.chars === true ? "chars" : "bytes",
+      getAllVariants: options.all === true,
+    },
+    ...langs,
+  )) {
+    if (printingMultipleLangs) console.log(result.language);
+    if (typeof result.result === "string") {
+      if (options.output !== undefined) {
+        fs.mkdirSync(path.dirname(options.output), { recursive: true });
+        fs.writeFileSync(
+          options.output +
+            (langs.length > 1 || !options.output.includes(".")
+              ? "." + findLang(result.language)!.extension
+              : ""),
+          result.result,
+        );
+      } else {
+        console.log(result.result);
+      }
+      if (result.warnings.length > 0) {
+        console.log("Warnings:");
+        console.log(result.warnings.map((x) => x.message).join("\n"));
+      }
+      if (options.debug === true) {
+        console.log("History:");
         console.log(
-          result.errors
-            .map(
-              (e) =>
-                e.message +
-                (e instanceof EmitError ? "\n" + debugEmit(e.expr) : ""),
-            )
-            .join("\n"),
+          result.history.map(([c, name]) => `${c} ${name}`).join("\n"),
+        );
+
+        if (result.errors.length > 0) {
+          console.log("Errors:");
+          console.log(
+            result.errors
+              .map(
+                (e) =>
+                  e.message +
+                  (e instanceof NotImplementedError
+                    ? "\n" + debugEmit(e.expr)
+                    : ""),
+              )
+              .join("\n"),
+          );
+        }
+      }
+    } else {
+      if (!printingMultipleLangs && langs.length > 1)
+        console.log(result.language);
+      handleError(result.result);
+    }
+    console.log("");
+  }
+
+  function handleError(e: unknown) {
+    if (e instanceof UserError) {
+      console.log(e.message);
+      if (e.source != null) {
+        const startLine = e.source.line === 0 ? 0 : e.source.line - 2;
+        console.log(
+          code
+            .split(/\r?\n/)
+            .slice(startLine, e.source.line)
+            .map((x, i) => `${startLine + i + 1}`.padStart(3, " ") + " " + x)
+            .join("\n") +
+            "\n" +
+            " ".repeat(e.source.column + 3) +
+            "^",
         );
       }
+    } else {
+      throw e;
     }
-  } else {
-    if (!printingMultipleLangs && langs.length > 1)
-      console.log(result.language);
-    handleError(result.result);
-  }
-  console.log("");
-}
-
-function handleError(e: unknown) {
-  if (e instanceof PolygolfError) {
-    console.log(e.message);
-    if (e.source != null) {
-      const startLine = e.source.line === 0 ? 0 : e.source.line - 2;
-      console.log(
-        code
-          .split(/\r?\n/)
-          .slice(startLine, e.source.line)
-          .map((x, i) => `${startLine + i + 1}`.padStart(3, " ") + " " + x)
-          .join("\n") +
-          "\n" +
-          " ".repeat(e.source.column + 3) +
-          "^",
-      );
-    }
-  } else {
-    throw e;
   }
 }

--- a/src/common/compile.test.ts
+++ b/src/common/compile.test.ts
@@ -3,7 +3,7 @@ import { type Language, type Plugin, search, required } from "./Language";
 import { EmitError } from "./emit";
 import compile from "./compile";
 import { compilationOptionsFromKeywords } from "@/markdown-tests";
-import { PolygolfError } from "./errors";
+import { UserError } from "./errors";
 
 const textLang: Language = {
   name: "text",
@@ -14,14 +14,14 @@ const textLang: Language = {
         .map((x) => {
           if (isOp()(x) && x.args.length > 0 && isText()(x.args[0]!)) {
             if (x.args[0].value.endsWith("X")) {
-              context.addWarning(new PolygolfError("global warning"), true);
+              context.addWarning(new UserError("global warning"), true);
               context.addWarning(
-                new PolygolfError("local warning that should not be visible"),
+                new UserError("local warning that should not be visible"),
                 false,
               );
             }
             context.addWarning(
-              new PolygolfError("local warning that should be visible"),
+              new UserError("local warning that should be visible"),
               false,
             );
             return [x.args[0].value];

--- a/src/common/compile.test.ts
+++ b/src/common/compile.test.ts
@@ -1,9 +1,8 @@
 import { isOp, isText, text } from "@/IR";
 import { type Language, type Plugin, search, required } from "./Language";
-import { EmitError } from "./emit";
 import compile from "./compile";
 import { compilationOptionsFromKeywords } from "@/markdown-tests";
-import { UserError } from "./errors";
+import { NotImplementedError, UserError } from "./errors";
 
 const textLang: Language = {
   name: "text",
@@ -14,18 +13,24 @@ const textLang: Language = {
         .map((x) => {
           if (isOp()(x) && x.args.length > 0 && isText()(x.args[0]!)) {
             if (x.args[0].value.endsWith("X")) {
-              context.addWarning(new UserError("global warning"), true);
               context.addWarning(
-                new UserError("local warning that should not be visible"),
+                new UserError("global warning", undefined),
+                true,
+              );
+              context.addWarning(
+                new UserError(
+                  "local warning that should not be visible",
+                  undefined,
+                ),
                 false,
               );
             }
             context.addWarning(
-              new UserError("local warning that should be visible"),
+              new UserError("local warning that should be visible", undefined),
               false,
             );
             return [x.args[0].value];
-          } else throw new EmitError(x);
+          } else throw new NotImplementedError(x);
         })
         .join("");
     },

--- a/src/common/compile.ts
+++ b/src/common/compile.ts
@@ -28,7 +28,7 @@ import {
   shorterBy,
 } from "./objective";
 import { readsFromArgv, readsFromStdin } from "./symbols";
-import { PolygolfError } from "./errors";
+import { InvariantError, UserError } from "./errors";
 import { charLength } from "./strings";
 import { getOutput } from "../interpreter";
 
@@ -114,7 +114,7 @@ export function applyAllToAllAndGetCounts(
 function getSingleOrUndefined<T>(x: T | T[] | undefined): T | undefined {
   if (Array.isArray(x)) {
     if (x.length > 1)
-      throw new Error(
+      throw new InvariantError(
         `Programming error. Expected at most 1 item, but got ${stringify(x)}.`,
       );
     return x[0];
@@ -324,7 +324,7 @@ function getVariantsByInputMethod(variants: Node[]): Map<boolean, Node[]> {
     };
   });
   if (variantsWithMethods.some((x) => x.readsFromArgv && x.readsFromStdin)) {
-    throw new PolygolfError("Program cannot read from both argv and stdin.");
+    throw new UserError("Program cannot read from both argv and stdin.");
   }
   return new Map<boolean, Node[]>(
     [true, false].map((preferStdin) => {

--- a/src/common/compile.ts
+++ b/src/common/compile.ts
@@ -223,6 +223,7 @@ export default function compile(
   if (errorlessVariants.length === 0) {
     for (const variant of variants) {
       (variant as CompilationResult).warnings = parsed!.warnings;
+      keepDistinctWarningsOnly(variant as CompilationResult);
     }
     if (options.getAllVariants) {
       return variants as CompilationResult[];

--- a/src/common/compile.ts
+++ b/src/common/compile.ts
@@ -324,7 +324,10 @@ function getVariantsByInputMethod(variants: Node[]): Map<boolean, Node[]> {
     };
   });
   if (variantsWithMethods.some((x) => x.readsFromArgv && x.readsFromStdin)) {
-    throw new UserError("Program cannot read from both argv and stdin.");
+    throw new UserError(
+      "Program cannot read from both argv and stdin.",
+      undefined,
+    );
   }
   return new Map<boolean, Node[]>(
     [true, false].map((preferStdin) => {

--- a/src/common/emit.ts
+++ b/src/common/emit.ts
@@ -2,14 +2,9 @@ import {
   type If,
   type IR,
   type Integer,
-  type Node,
   type ConditionalOp,
   isOfKind,
-  VirtualOpCodes,
-  argsOf,
 } from "../IR";
-import { debugEmit } from "./compile";
-import { UserError } from "./errors";
 import { $ } from "./fragments";
 import type { TokenTree } from "./Language";
 import type { Spine } from "./Spine";

--- a/src/common/emit.ts
+++ b/src/common/emit.ts
@@ -9,7 +9,7 @@ import {
   argsOf,
 } from "../IR";
 import { debugEmit } from "./compile";
-import { PolygolfError } from "./errors";
+import { UserError } from "./errors";
 import { $ } from "./fragments";
 import type { TokenTree } from "./Language";
 import type { Spine } from "./Spine";
@@ -77,25 +77,6 @@ export function containsMultiNode(exprs: readonly IR.Node[]): boolean {
     }
   }
   return false;
-}
-
-export class EmitError extends PolygolfError {
-  expr: Node;
-  constructor(expr: Node, detail?: string) {
-    if (detail === undefined && "op" in expr && expr.op !== null) {
-      detail = [
-        expr.op,
-        ...VirtualOpCodes.filter((x) => argsOf[x](expr) !== undefined),
-      ].join(", ");
-    }
-    detail = detail === undefined ? "" : ` (${detail})`;
-    const message =
-      `emit error - ${expr.kind}${detail} not supported.\n` + debugEmit(expr);
-    super(message, expr.source);
-    this.name = "EmitError";
-    this.expr = expr;
-    Object.setPrototypeOf(this, EmitError.prototype);
-  }
 }
 
 export function shortest(x: string[]) {

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -10,7 +10,7 @@ export class InvariantError extends Error {
       cause === undefined ? undefined : { cause },
     );
     this.name = "InvariantError";
-    Object.setPrototypeOf(this, UserError.prototype);
+    Object.setPrototypeOf(this, InvariantError.prototype);
   }
 }
 

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,11 +1,62 @@
-import { type SourcePointer } from "../IR";
+import { VirtualOpCodes, type Node, type SourcePointer, argsOf } from "../IR";
 
-export class PolygolfError extends Error {
+/**
+ * This is an unrecoverable error. This should never be thrown unless there's a bug in Polygolf.
+ */
+export class InvariantError extends Error {
+  constructor(message: string) {
+    super(
+      "A Polygolf Invariant was broken. This is a bug in Polygolf.\n" + message,
+    );
+    this.name = "InvariantError";
+    Object.setPrototypeOf(this, UserError.prototype);
+  }
+}
+
+/**
+ * This is caused by javascript target emitting a code that cannot be parsed.
+ */
+export class InterpreterError extends InvariantError {
+  constructor(executedJavascript: string) {
+    super(
+      `Error while executing the following javascript:\n${executedJavascript}`,
+    );
+    this.name = "InterpreterError";
+    Object.setPrototypeOf(this, InterpreterError.prototype);
+  }
+}
+
+/**
+ * This is an error caused by a user of Polygolf. Parse errors, typecheck errors, etc.
+ */
+export class UserError extends Error {
   source?: SourcePointer;
-  constructor(message: string, source?: SourcePointer) {
+  constructor(message: string, source: SourcePointer | Node | undefined) {
     super(message);
-    this.source = source;
-    this.name = "PolygolfError";
-    Object.setPrototypeOf(this, PolygolfError.prototype);
+    this.source =
+      source !== undefined && "kind" in source ? source.source : source;
+    this.name = "UserError";
+    Object.setPrototypeOf(this, UserError.prototype);
+  }
+}
+
+/**
+ * Particular feature is not implemented, but it might be in future.
+ */
+export class NotImplementedError extends UserError {
+  expr: Node;
+  constructor(expr: Node, detail?: string) {
+    if (detail === undefined && "op" in expr && expr.op !== null) {
+      detail = [
+        expr.op,
+        ...VirtualOpCodes.filter((x) => argsOf[x](expr) !== undefined),
+      ].join(", ");
+    }
+    detail = detail === undefined ? "" : ` (${detail})`;
+    const message = `emit error - ${expr.kind}${detail} not supported.\n`;
+    super(message, expr.source);
+    this.name = "EmitError";
+    this.expr = expr;
+    Object.setPrototypeOf(this, NotImplementedError.prototype);
   }
 }

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -4,25 +4,13 @@ import { VirtualOpCodes, type Node, type SourcePointer, argsOf } from "../IR";
  * This is an unrecoverable error. This should never be thrown unless there's a bug in Polygolf.
  */
 export class InvariantError extends Error {
-  constructor(message: string) {
+  constructor(message: string, cause?: Error) {
     super(
       "A Polygolf Invariant was broken. This is a bug in Polygolf.\n" + message,
+      cause === undefined ? undefined : { cause },
     );
     this.name = "InvariantError";
     Object.setPrototypeOf(this, UserError.prototype);
-  }
-}
-
-/**
- * This is caused by javascript target emitting a code that cannot be parsed.
- */
-export class InterpreterError extends InvariantError {
-  constructor(executedJavascript: string) {
-    super(
-      `Error while executing the following javascript:\n${executedJavascript}`,
-    );
-    this.name = "InterpreterError";
-    Object.setPrototypeOf(this, InterpreterError.prototype);
   }
 }
 
@@ -31,8 +19,12 @@ export class InterpreterError extends InvariantError {
  */
 export class UserError extends Error {
   source?: SourcePointer;
-  constructor(message: string, source: SourcePointer | Node | undefined) {
-    super(message);
+  constructor(
+    message: string,
+    source: SourcePointer | Node | undefined,
+    cause?: Error,
+  ) {
+    super(message, cause === undefined ? undefined : { cause });
     this.source =
       source !== undefined && "kind" in source ? source.source : source;
     this.name = "UserError";
@@ -45,7 +37,7 @@ export class UserError extends Error {
  */
 export class NotImplementedError extends UserError {
   expr: Node;
-  constructor(expr: Node, detail?: string) {
+  constructor(expr: Node, detail?: string, cause?: Error) {
     if (detail === undefined && "op" in expr && expr.op !== null) {
       detail = [
         expr.op,
@@ -54,7 +46,7 @@ export class NotImplementedError extends UserError {
     }
     detail = detail === undefined ? "" : ` (${detail})`;
     const message = `emit error - ${expr.kind}${detail} not supported.\n`;
-    super(message, expr.source);
+    super(message, expr.source, cause);
     this.name = "EmitError";
     this.expr = expr;
     Object.setPrototypeOf(this, NotImplementedError.prototype);

--- a/src/common/expandVariants.ts
+++ b/src/common/expandVariants.ts
@@ -17,6 +17,7 @@ export function expandVariants(program: IR.Node): IR.Node[] {
   if (n > 16)
     throw new UserError(
       `Variant count ${n} exceeds arbitrary limit. Giving up.`,
+      program,
     );
   return allVariantOptions(program).map((x) => structuredClone(x));
 }

--- a/src/common/expandVariants.ts
+++ b/src/common/expandVariants.ts
@@ -1,4 +1,5 @@
 import { type IR } from "../IR";
+import { InvariantError, UserError } from "./errors";
 import {
   fromChildRemapFunc,
   getChild,
@@ -14,13 +15,15 @@ import {
 export function expandVariants(program: IR.Node): IR.Node[] {
   const n = numVariants(program);
   if (n > 16)
-    throw new Error(`Variant count ${n} exceeds arbitrary limit. Giving up`);
+    throw new UserError(
+      `Variant count ${n} exceeds arbitrary limit. Giving up.`,
+    );
   return allVariantOptions(program).map((x) => structuredClone(x));
 }
 
 export function getOnlyVariant(program: IR.Node): IR.Node {
   if (numVariants(program) > 1) {
-    throw new Error("Program contains multiple variants!");
+    throw new InvariantError("Program contains multiple variants!");
   }
   return allVariantOptions(program)[0];
 }

--- a/src/common/getType.test.ts
+++ b/src/common/getType.test.ts
@@ -34,7 +34,7 @@ import {
   lengthToArrayIndexType as length,
   isPhysicalOpCode,
 } from "IR";
-import { PolygolfError } from "./errors";
+import { UserError } from "./errors";
 import { calcTypeAndResolveOpCode, getType } from "./getType";
 
 const ascii = (x: number | IntegerType = int(0)) => text(x, true);
@@ -159,7 +159,7 @@ describe("Assignment", () => {
     const aLHS = id("a");
     const expr = assignment(aLHS, op.add(id("a"), e(int(1))));
     expect(() => calcTypeAndResolveOpCode(aLHS, block([expr]))).toThrow(
-      PolygolfError,
+      UserError,
     );
   });
 });

--- a/src/common/getType.ts
+++ b/src/common/getType.ts
@@ -90,11 +90,13 @@ export function getTypeAndResolveOpCode(
     return t;
   } catch (e) {
     currentlyFinding.delete(expr);
-    /*
-    if (e instanceof Error && !(e instanceof PolygolfError)) {
-      throw new PolygolfError(e.message, expr.source);
+    if (
+      e instanceof Error &&
+      !(e instanceof InvariantError) &&
+      !(e instanceof UserError)
+    ) {
+      throw new InvariantError(e.message, e);
     }
-    */
     throw e;
   }
 }
@@ -607,6 +609,7 @@ function _getOpCodeTypeFromTypes(
         `Type error. start index + length must be nonpositive, but got ${toString(
           startPlusLength,
         )}.`,
+        undefined,
       );
     }
     case "slice[List]":
@@ -621,6 +624,7 @@ function _getOpCodeTypeFromTypes(
         `Type error. start index + length must be nonpositive, but got ${toString(
           startPlusLength,
         )}.`,
+        undefined,
       );
     }
     case "ord[codepoint]":
@@ -704,8 +708,8 @@ function getOpCodeType(expr: Op, program: Node): Type {
   } catch (e) {
     if (e instanceof UserError) {
       e.source = expr.source;
-      throw e;
     }
+    throw e;
   }
 }
 
@@ -750,7 +754,10 @@ function resolveUnresolvedOpCode(
 
   if (expr.op === (".." as any) && legacyDotDot.includes(opCode)) {
     addWarning(
-      new UserError(`Deprecated alias .. used. Use ${opCode} or + instead.`),
+      new UserError(
+        `Deprecated alias .. used. Use ${opCode} or + instead.`,
+        expr,
+      ),
     );
   }
   const got = opArgsWithDefaults(opCode, expr.args).map((x) =>

--- a/src/common/objective.ts
+++ b/src/common/objective.ts
@@ -1,4 +1,5 @@
 import { type CompilationOptions, type CompilationResult } from "./compile";
+import { InvariantError } from "./errors";
 import { byteLength, charLength } from "./strings";
 
 export type Objective = "bytes" | "chars";
@@ -14,15 +15,28 @@ function isError(x: any): x is Error {
   return x instanceof Error;
 }
 
+function withInvariantErrorWarningsFrom(
+  a: CompilationResult,
+  b: CompilationResult,
+) {
+  return {
+    ...a,
+    warnings: [
+      ...a.warnings,
+      ...b.warnings.filter((x) => x instanceof InvariantError),
+    ],
+  };
+}
+
 export function shorterBy(
   obj: ObjectiveFunc,
 ): (a: CompilationResult, b: CompilationResult) => CompilationResult {
   return (a, b) =>
     isError(a.result)
-      ? b
+      ? withInvariantErrorWarningsFrom(b, a)
       : isError(b.result)
-        ? a
+        ? withInvariantErrorWarningsFrom(a, b)
         : obj(a.result) < obj(b.result)
-          ? a
-          : b;
+          ? withInvariantErrorWarningsFrom(a, b)
+          : withInvariantErrorWarningsFrom(b, a);
 }

--- a/src/common/objective.ts
+++ b/src/common/objective.ts
@@ -19,13 +19,17 @@ function withInvariantErrorWarningsFrom(
   a: CompilationResult,
   b: CompilationResult,
 ) {
-  return {
+  const res = {
     ...a,
     warnings: [
       ...a.warnings,
       ...b.warnings.filter((x) => x instanceof InvariantError),
     ],
   };
+  if (typeof b.result !== "string" && b.result instanceof InvariantError) {
+    res.warnings.push(b.result);
+  }
+  return res;
 }
 
 export function shorterBy(

--- a/src/common/symbols.ts
+++ b/src/common/symbols.ts
@@ -10,7 +10,7 @@ import {
   type Type,
   toString,
 } from "../IR";
-import { PolygolfError } from "./errors";
+import { InvariantError, UserError } from "./errors";
 import { $, getChildFragments, type PathFragment } from "./fragments";
 import { getCollectionTypes, getType } from "./getType";
 import { programToSpine, type Spine } from "./Spine";
@@ -20,7 +20,7 @@ class SymbolTable extends Map<string, Spine> {
   getRequired(key: string) {
     const ret = this.get(key);
     if (ret === undefined)
-      throw new Error(
+      throw new UserError(
         `Symbol not found: ${key}. ` +
           `Defined symbols: ${[...this.keys()].join(", ")}`,
       );
@@ -54,7 +54,7 @@ export function symbolTableRoot(program: IR.Node): SymbolTable {
       (name, i) => i > 0 && sortedNames[i - 1] === name,
     );
     if (duplicate !== undefined)
-      throw new Error(`Duplicate symbol: ${duplicate}`);
+      throw new InvariantError(`Duplicate symbol: ${duplicate}`);
   }
   symbolTableCache.set(program, table);
   return table;
@@ -123,17 +123,17 @@ function getTypeFromBinding(name: string, spine: Spine): Type {
         node.variable.type !== undefined &&
         !isSubtype(assignedType, node.variable.type)
       )
-        throw new PolygolfError(
+        throw new UserError(
           `Value of type ${toString(assignedType)} cannot be assigned to ${
             (node.variable as Identifier).name
           } of type ${toString(node.variable.type)}`,
-          node.source,
+          node,
         );
       return node.variable.type ?? assignedType;
     }
     default:
-      throw new Error(
-        `Programming error: node of type ${node.kind} does not bind any symbol`,
+      throw new InvariantError(
+        `Node of type ${node.kind} does not bind any symbol`,
       );
   }
 }

--- a/src/common/symbols.ts
+++ b/src/common/symbols.ts
@@ -23,6 +23,7 @@ class SymbolTable extends Map<string, Spine> {
       throw new UserError(
         `Symbol not found: ${key}. ` +
           `Defined symbols: ${[...this.keys()].join(", ")}`,
+        undefined,
       );
     return ret;
   }

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -36,17 +36,21 @@ const javascriptForInterpreting = {
   ],
 };
 
-const outputCache = new Map<Node, unknown>();
+const outputCache = new Map<Node, string | Error>();
 
-export function getOutput(program: Node) {
+export function getOutputOrError(program: Node) {
   if (!outputCache.has(program)) {
     try {
       outputCache.set(program, _getOutput(program));
     } catch (e) {
-      outputCache.set(program, e);
+      outputCache.set(program, e as Error);
     }
   }
-  const res = outputCache.get(program);
+  return outputCache.get(program)!;
+}
+
+export function getOutputOrThrow(program: Node) {
+  const res = getOutputOrError(program);
   if (typeof res === "string") return res;
   throw res;
 }

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -7,7 +7,7 @@ import {
   isOfKind,
 } from "../IR";
 import { readsFromInput } from "../common/symbols";
-import { InterpreterError, UserError } from "../common/errors";
+import { InvariantError, UserError } from "../common/errors";
 import { compileVariant } from "../common/compile";
 import javascriptLanguage from "../languages/javascript";
 import { required } from "../common/Language";
@@ -88,7 +88,10 @@ function _getOutput(program: Node): string {
   } catch (e) {
     if (e instanceof Error) {
       if (e instanceof SyntaxError) {
-        throw new InterpreterError(jsCode.result);
+        throw new InvariantError(
+          `Error while executing the following javascript:\n${jsCode.result}`,
+          e,
+        );
       }
       if (!(e instanceof UserError)) {
         throw new UserError("Error while executing code.", undefined);

--- a/src/languages/clojure/emit.ts
+++ b/src/languages/clojure/emit.ts
@@ -1,9 +1,4 @@
-import {
-  EmitError,
-  emitIntLiteral,
-  emitTextFactory,
-  getIfChain,
-} from "../../common/emit";
+import { emitIntLiteral, emitTextFactory, getIfChain } from "../../common/emit";
 import {
   isInt,
   isForEachRange,
@@ -19,6 +14,7 @@ import {
 import { type Spine } from "../../common/Spine";
 import type { CompilationContext } from "../../common/compile";
 import { $ } from "../../common/fragments";
+import { NotImplementedError } from "../../common/errors";
 
 const emitClojureText = emitTextFactory({
   '"TEXT"': { "\\": `\\\\`, "\r": `\\r`, '"': `\\"` },
@@ -98,7 +94,8 @@ export class ClojureEmitter extends VisitorEmitter {
       case "FunctionCall":
         return list($.func, $.args.join());
       case "RangeIndexCall":
-        if (!isInt(1n)(n.step)) throw new EmitError(n, "step not equal one");
+        if (!isInt(1n)(n.step))
+          throw new NotImplementedError(n, "step not equal one");
         return isInt(0n)(n.low)
           ? list("take", $.high, $.collection)
           : list("subvec", list("vec", $.collection), $.low, $.high);
@@ -118,7 +115,7 @@ export class ClojureEmitter extends VisitorEmitter {
       case "KeyValue":
         return [$.key, $.value];
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/golfscript/emit.ts
+++ b/src/languages/golfscript/emit.ts
@@ -3,11 +3,12 @@ import {
   VisitorEmitter,
   type EmitterVisitResult,
 } from "../../common/Language";
-import { EmitError, emitTextFactory } from "../../common/emit";
+import { emitTextFactory } from "../../common/emit";
 import { integerType, isInt, isSubtype, isOp, type Node } from "../../IR";
 import { getType } from "../../common/getType";
 import type { Spine } from "../../common/Spine";
 import { $ } from "../../common/fragments";
+import { NotImplementedError } from "../../common/errors";
 
 const emitGolfscriptText = emitTextFactory({
   '"TEXT"': { "\\": "\\\\", '"': `\\"` },
@@ -50,7 +51,7 @@ export class GolfscriptEmitter extends VisitorEmitter {
               isInt()(a.node) && a.node.value < 0n
                 ? [(-a.node.value).toString(), "-"]
                 : [a, "+"];
-          } else throw new EmitError(n, "inclusive");
+          } else throw new NotImplementedError(n, "inclusive");
         } else {
           collection = $.collection;
         }
@@ -117,7 +118,7 @@ export class GolfscriptEmitter extends VisitorEmitter {
           isInt(1n)(n.step) ? [] : [$.step, "%"],
         ];
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/janet/emit.ts
+++ b/src/languages/janet/emit.ts
@@ -19,6 +19,7 @@ import {
 import { type Spine } from "../../common/Spine";
 import type { CompilationContext } from "../../common/compile";
 import { $ } from "../../common/fragments";
+import { InvariantError } from "@/common/errors";
 
 const emitJanetText = emitTextFactory({
   '"TEXT"': { "\\": `\\\\`, "\n": `\\n`, "\r": `\\r`, '"': `\\"` },
@@ -49,7 +50,9 @@ export class JanetEmitter extends VisitorEmitter {
         if (n.targetType === "array") {
           return ["@[;", "$GLUE$", $.expr, "]"];
         }
-        throw new EmitError(n, "unsuported cast target type");
+        throw new InvariantError(
+          `Unsuported cast target type '${n.targetType}'.`,
+        );
       case "Block": {
         return prop === "consequent" || prop === "alternate"
           ? list("do", $.children.join())

--- a/src/languages/janet/emit.ts
+++ b/src/languages/janet/emit.ts
@@ -1,9 +1,4 @@
-import {
-  EmitError,
-  emitIntLiteral,
-  emitTextFactory,
-  getIfChain,
-} from "../../common/emit";
+import { emitIntLiteral, emitTextFactory, getIfChain } from "../../common/emit";
 import {
   isInt,
   isForEachRange,
@@ -17,9 +12,9 @@ import {
   type EmitterVisitResult,
 } from "../../common/Language";
 import { type Spine } from "../../common/Spine";
-import type { CompilationContext } from "../../common/compile";
+import { debugEmit, type CompilationContext } from "../../common/compile";
 import { $ } from "../../common/fragments";
-import { InvariantError } from "@/common/errors";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 const emitJanetText = emitTextFactory({
   '"TEXT"': { "\\": `\\\\`, "\n": `\\n`, "\r": `\\r`, '"': `\\"` },
@@ -98,9 +93,8 @@ export class JanetEmitter extends VisitorEmitter {
       case "VarDeclarationWithAssignment": {
         const assignment = n.assignment;
         if (assignment.kind !== "Assignment") {
-          throw new EmitError(
-            n,
-            `Declaration cannot contain ${assignment.kind}`,
+          throw new InvariantError(
+            `Declaration cannot contain ${assignment.kind}. ${debugEmit(n)}`,
           );
         }
         return $.assignment;
@@ -120,7 +114,8 @@ export class JanetEmitter extends VisitorEmitter {
       case "FunctionCall":
         return list($.func, $.args.join());
       case "RangeIndexCall":
-        if (!isInt(1n)(n.step)) throw new EmitError(n, "step not equal one");
+        if (!isInt(1n)(n.step))
+          throw new NotImplementedError(n, "step not equal one");
         return isInt(0n)(n.low)
           ? list("take", $.high, $.collection)
           : list("slice", $.collection, $.low, $.high);
@@ -139,7 +134,7 @@ export class JanetEmitter extends VisitorEmitter {
       case "KeyValue":
         return [$.key, $.value];
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/javascript/emit.ts
+++ b/src/languages/javascript/emit.ts
@@ -3,11 +3,12 @@ import {
   PrecedenceVisitorEmitter,
   type Token,
 } from "../../common/Language";
-import { EmitError, emitIntLiteral, emitTextFactory } from "../../common/emit";
+import { emitIntLiteral, emitTextFactory } from "../../common/emit";
 import { isText, isOfKind, type Node, uniqueId } from "../../IR";
 import { type CompilationContext } from "../../common/compile";
 import { $, type PathFragment } from "../../common/fragments";
 import type { Spine } from "../../common/Spine";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 function escapeRegExp(string: string) {
   // https://stackoverflow.com/a/6969486/14611638
@@ -81,9 +82,7 @@ function binaryPrecedence(opname: string): number {
       return 3;
   }
   if (opname.endsWith("=")) return 0;
-  throw new Error(
-    `Programming error - unknown Javascript binary operator '${opname}.'`,
-  );
+  throw new InvariantError(`Unknown Javascript binary operator '${opname}.'`);
 }
 
 export class JavascriptEmitter extends PrecedenceVisitorEmitter {
@@ -150,7 +149,9 @@ export class JavascriptEmitter extends PrecedenceVisitorEmitter {
         if (n.targetType === "array") {
           return ["[...", $.expr, "]"];
         }
-        throw new EmitError(n, "unsuported cast target type");
+        throw new InvariantError(
+          `Unsuported cast target type ${n.targetType}.`,
+        );
       case "VarDeclarationWithAssignment":
         return ["let", $.assignment];
       case "Block":
@@ -244,7 +245,7 @@ export class JavascriptEmitter extends PrecedenceVisitorEmitter {
         ];
 
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/lua/emit.ts
+++ b/src/languages/lua/emit.ts
@@ -1,5 +1,5 @@
 import { type CompilationContext } from "../../common/compile";
-import { EmitError, emitIntLiteral, emitTextFactory } from "../../common/emit";
+import { emitIntLiteral, emitTextFactory } from "../../common/emit";
 import { isInt, isOp, type Node } from "../../IR";
 import {
   defaultDetokenizer,
@@ -7,6 +7,7 @@ import {
 } from "../../common/Language";
 import type { Spine } from "../../common/Spine";
 import { $, type PathFragment } from "../../common/fragments";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 const emitLuaText = emitTextFactory(
   {
@@ -57,9 +58,7 @@ function binaryPrecedence(opname: string): number {
     case "or":
       return 1;
   }
-  throw new Error(
-    `Programming error - unknown Lua binary operator '${opname}.'`,
-  );
+  throw new InvariantError(`Unknown Lua binary operator '${opname}.'`);
 }
 
 export class LuaEmitter extends PrecedenceVisitorEmitter {
@@ -158,6 +157,6 @@ export class LuaEmitter extends PrecedenceVisitorEmitter {
       case "KeyValue":
         return [$.key, "=", $.value];
     }
-    throw new EmitError(e);
+    throw new NotImplementedError(e);
   }
 }

--- a/src/languages/nim/emit.ts
+++ b/src/languages/nim/emit.ts
@@ -5,7 +5,6 @@ import {
 import {
   emitTextFactory,
   joinTrees,
-  EmitError,
   emitIntLiteral,
   getIfChain,
 } from "../../common/emit";
@@ -13,6 +12,7 @@ import { type Array, isInt, type Node, type Text, type If } from "../../IR";
 import { type CompilationContext } from "../../common/compile";
 import { type Spine } from "../../common/Spine";
 import { $, type PathFragment } from "../../common/fragments";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 function escape(x: number, i: number, arr: number[]) {
   if (x < 100 && (i === arr.length - 1 || arr[i + 1] < 48 || arr[i + 1] > 57))
@@ -78,9 +78,7 @@ function binaryPrecedence(opname: string): number {
       return 1;
   }
   if (opname.endsWith("=")) return 0;
-  throw new Error(
-    `Programming error - unknown Nim binary operator '${opname}.'`,
-  );
+  throw new InvariantError(`Unknown Nim binary operator '${opname}.'`);
 }
 
 export class NimEmitter extends PrecedenceVisitorEmitter {
@@ -201,7 +199,7 @@ export class NimEmitter extends PrecedenceVisitorEmitter {
       }
       case "Variants":
       case "ForCLike":
-        throw new EmitError(n);
+        throw new InvariantError("");
       case "Assignment":
         return [$.variable, "=", $.expr];
       case "ManyToManyAssignment":
@@ -264,10 +262,10 @@ export class NimEmitter extends PrecedenceVisitorEmitter {
       case "IndexCall":
         return [$.collection, "$GLUE$", "[", $.index, "]"];
       case "RangeIndexCall":
-        if (!isInt(1n)(n.step)) throw new EmitError(n, "step");
+        if (!isInt(1n)(n.step)) throw new NotImplementedError(n, "step");
         return [$.collection, "$GLUE$", "[", $.low, "..<", $.high, "]"];
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/python/emit.ts
+++ b/src/languages/python/emit.ts
@@ -6,7 +6,6 @@ import {
 } from "../../common/Language";
 import {
   containsMultiNode,
-  EmitError,
   emitIntLiteral,
   emitTextFactory,
   getIfChain,
@@ -16,6 +15,7 @@ import { isInt, isText, id, type Node, type If } from "../../IR";
 import { type CompilationContext } from "../../common/compile";
 import { $, type PathFragment } from "../../common/fragments";
 import { type Spine } from "../../common/Spine";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 export const emitPythonText = emitTextFactory(
   {
@@ -64,9 +64,7 @@ function binaryPrecedence(opname: string): number {
       return 1;
   }
   if (opname.endsWith("=")) return 0;
-  throw new Error(
-    `Programming error - unknown Python binary operator '${opname}'.`,
-  );
+  throw new InvariantError(`Unknown Python binary operator '${opname}'.`);
 }
 
 function unaryPrecedence(opname: string): number {
@@ -77,9 +75,7 @@ function unaryPrecedence(opname: string): number {
     case "not":
       return 3;
   }
-  throw new Error(
-    `Programming error - unknown Python unary operator '${opname}.'`,
-  );
+  throw new InvariantError(`Unknown Python unary operator '${opname}.'`);
 }
 
 export class PythonEmitter extends PrecedenceVisitorEmitter {
@@ -132,7 +128,9 @@ export class PythonEmitter extends PrecedenceVisitorEmitter {
         if (n.targetType === "set") {
           return ["{*", $.expr, "}"];
         }
-        throw new EmitError(n, "unsuported cast target type");
+        throw new InvariantError(
+          `Unsuported cast target type ${n.targetType}.`,
+        );
       case "Block":
         return $.children.join(
           spine.isRoot || containsMultiNode(n.children) ? "\n" : ";",
@@ -231,7 +229,7 @@ export class PythonEmitter extends PrecedenceVisitorEmitter {
         ];
       }
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 }

--- a/src/languages/swift/emit.ts
+++ b/src/languages/swift/emit.ts
@@ -1,14 +1,10 @@
 import { PrecedenceVisitorEmitter, type Token } from "../../common/Language";
-import {
-  EmitError,
-  emitIntLiteral,
-  emitTextFactory,
-  joinTrees,
-} from "../../common/emit";
+import { emitIntLiteral, emitTextFactory, joinTrees } from "../../common/emit";
 import { type Node } from "../../IR";
 import { type CompilationContext } from "../../common/compile";
 import { $, type PathFragment } from "../../common/fragments";
 import type { Spine } from "../../common/Spine";
+import { InvariantError, NotImplementedError } from "../../common/errors";
 
 const unicode01to09repls = {
   "\u{1}": `\\u{1}`,
@@ -95,9 +91,7 @@ function binaryPrecedence(opname: string): number {
       return 1;
   }
   if (opname.endsWith("=")) return 0;
-  throw new Error(
-    `Programming error - unknown Swift binary operator '${opname}.'`,
-  );
+  throw new InvariantError(`Unknown Swift binary operator '${opname}.'`);
 }
 
 function unaryPrecedence(opname: string): number {
@@ -164,7 +158,7 @@ export class SwiftEmitter extends PrecedenceVisitorEmitter {
         ];
       case "Variants":
       case "ForCLike":
-        throw new EmitError(n);
+        throw new InvariantError("");
       case "Assignment":
         return [$.variable, "=", $.expr];
       case "NamedArg":
@@ -209,7 +203,7 @@ export class SwiftEmitter extends PrecedenceVisitorEmitter {
         return [$.collection, "[", $.low, "..<", $.high, "]"];
 
       default:
-        throw new EmitError(n);
+        throw new NotImplementedError(n);
     }
   }
 

--- a/src/languages/text/index.ts
+++ b/src/languages/text/index.ts
@@ -1,4 +1,4 @@
-import { getOutput } from "../../interpreter";
+import { getOutputOrThrow } from "../../interpreter";
 import type { Language } from "../../common/Language";
 
 const textLanguage: Language = {
@@ -7,7 +7,7 @@ const textLanguage: Language = {
   phases: [],
   emitter: {
     emit(x) {
-      return getOutput(x).trimEnd();
+      return getOutputOrThrow(x).trimEnd();
     },
   },
 };

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -17,7 +17,7 @@ import {
   toString,
 } from "../IR";
 import { getType } from "../common/getType";
-import { UserError } from "../common/errors";
+import { InvariantError, NotImplementedError } from "../common/errors";
 import { $ } from "../common/fragments";
 import type { CompilationContext } from "@/common/compile";
 
@@ -78,8 +78,8 @@ export function renameIdents(
       if (isUserIdent()(node)) {
         const outputName = identMap.get(node.name);
         if (outputName === undefined) {
-          throw new Error(
-            `Programming error. Incomplete identMap. Defined: ${JSON.stringify([
+          throw new InvariantError(
+            `Incomplete identMap. Defined: ${JSON.stringify([
               ...identMap.keys(),
             ])}, missing ${JSON.stringify(node.name)}`,
           );
@@ -170,9 +170,9 @@ export function clone(
       const type = getType(node, spine);
       const res = mapping(node, type, spine);
       if (res === undefined) {
-        throw new UserError(
+        throw new NotImplementedError(
+          node,
           `Could not clone an identifier of type ${toString(type)}`,
-          node.source,
         );
       }
       context.skipChildren();

--- a/src/plugins/idents.ts
+++ b/src/plugins/idents.ts
@@ -17,7 +17,7 @@ import {
   toString,
 } from "../IR";
 import { getType } from "../common/getType";
-import { PolygolfError } from "../common/errors";
+import { UserError } from "../common/errors";
 import { $ } from "../common/fragments";
 import type { CompilationContext } from "@/common/compile";
 
@@ -170,7 +170,7 @@ export function clone(
       const type = getType(node, spine);
       const res = mapping(node, type, spine);
       if (res === undefined) {
-        throw new PolygolfError(
+        throw new UserError(
           `Could not clone an identifier of type ${toString(type)}`,
           node.source,
         );

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -31,7 +31,7 @@ import {
   isText,
   uniqueId,
 } from "../IR";
-import { UserError } from "../common/errors";
+import { InvariantError, UserError } from "../common/errors";
 import { mapOps } from "./ops";
 import { $ } from "../common/fragments";
 import { byteLength, charLength } from "../common/strings";
@@ -49,7 +49,7 @@ export function forRangeToWhile(node: Node, spine: Spine) {
     const low = getType(start, spine);
     const high = getType(end, spine);
     if (low.kind !== "integer" || high.kind !== "integer") {
-      throw new Error(`Unexpected type (${low.kind},${high.kind})`);
+      throw new InvariantError(`Unexpected type (${low.kind},${high.kind})`);
     }
     const increment = assignment(node.variable, op.add(node.variable, step));
     return block([
@@ -71,7 +71,7 @@ export function forRangeToForCLike(node: Node, spine: Spine) {
     const low = getType(start, spine);
     const high = getType(end, spine);
     if (low.kind !== "integer" || high.kind !== "integer") {
-      throw new Error(`Unexpected type (${low.kind},${high.kind})`);
+      throw new InvariantError(`Unexpected type (${low.kind},${high.kind})`);
     }
     const variable = node.variable ?? uniqueId();
     return forCLike(

--- a/src/plugins/loops.ts
+++ b/src/plugins/loops.ts
@@ -31,7 +31,7 @@ import {
   isText,
   uniqueId,
 } from "../IR";
-import { PolygolfError } from "../common/errors";
+import { UserError } from "../common/errors";
 import { mapOps } from "./ops";
 import { $ } from "../common/fragments";
 import { byteLength, charLength } from "../common/strings";
@@ -192,7 +192,7 @@ export function assertForArgvTopLevel(node: Node, spine: Spine) {
     for (const kind of spine.compactMap((x) => x.kind)) {
       if (kind === "ForArgv") {
         if (forArgvSeen)
-          throw new PolygolfError(
+          throw new UserError(
             "Only a single for_argv node allowed.",
             node.source,
           );
@@ -207,7 +207,7 @@ export function assertForArgvTopLevel(node: Node, spine: Spine) {
         (spine.parent?.node.kind === "Block" && spine.parent.isRoot)
       )
     ) {
-      throw new PolygolfError(
+      throw new UserError(
         "Node for_argv only allowed at the top level.",
         node.source,
       );

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -66,6 +66,7 @@ function needsBigint(
         if (res === undefined) {
           throw new UserError(
             `Operation that is not supported on bigints encountered. (${op})`,
+            parent,
           );
         }
         if (res === "bigint" && node.targetType !== "bigint") {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1,5 +1,5 @@
 import type { PluginVisitor, Spine } from "../common/Spine";
-import { PolygolfError } from "../common/errors";
+import { UserError } from "../common/errors";
 import { getType } from "../common/getType";
 import {
   int64Type,
@@ -27,7 +27,7 @@ export function assertInt64(node: Node, spine: Spine) {
     return; // stuff like builtin identifiers etc. throw
   }
   if (isSubtype(type, integerType()) && !isSubtype(type, int64Type)) {
-    throw new PolygolfError(
+    throw new UserError(
       `Integer value that doesn't provably fit into a int64 type encountered.`,
       node.source,
     );
@@ -64,7 +64,7 @@ function needsBigint(
         const op = isOp()(parent) ? parent.op : "Assignment";
         const res = (allowed as any)[op];
         if (res === undefined) {
-          throw new PolygolfError(
+          throw new UserError(
             `Operation that is not supported on bigints encountered. (${op})`,
           );
         }


### PR DESCRIPTION
Closes #259 
There are now three main types of errors:
1. `InvariantError` Ideally, these should never occur, they mean that an invariant that should hold, doesn't. A bug that needs fixing.
2. `NotImplementedError` This is typically thrown in emitters to signal that the IR could not be emitted to the target lang. This is part of the normal compilation workflow a different variant might be chosen instead. When a certain Polygolf feature is not covered, the result of a compilation is this error.
3. `UserError` An error caused by the Polygolf user - parse errors, var reference errors, typecheck errors, deprecated feature errors, etc. 